### PR TITLE
Improve Incremental Builds

### DIFF
--- a/ViewGeneratorCore/ViewGeneratorCore.csproj
+++ b/ViewGeneratorCore/ViewGeneratorCore.csproj
@@ -8,7 +8,7 @@
     <Product>ViewGeneratorCore</Product>
     <Description>Generates .NET View bindings from typescript</Description>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>1.0.225</Version>
+    <Version>1.0.226</Version>
     <PackageId>ViewGeneratorCore</PackageId>
     <Authors>OutSystems</Authors>
     <PackageTags>Library</PackageTags>

--- a/ViewGeneratorCore/ViewGeneratorCore.csproj
+++ b/ViewGeneratorCore/ViewGeneratorCore.csproj
@@ -8,7 +8,7 @@
     <Product>ViewGeneratorCore</Product>
     <Description>Generates .NET View bindings from typescript</Description>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>1.0.224</Version>
+    <Version>1.0.225</Version>
     <PackageId>ViewGeneratorCore</PackageId>
     <Authors>OutSystems</Authors>
     <PackageTags>Library</PackageTags>

--- a/ViewGeneratorCore/build/ViewGeneratorCore.targets
+++ b/ViewGeneratorCore/build/ViewGeneratorCore.targets
@@ -39,7 +39,7 @@
   </Target>
 
     <Target Name="VGC_GetInputs" DependsOnTargets="VGC_SetVariables;VGC_Setup">
-        <Exec ConsoleToMSBuild="True" Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -l -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;">
+        <Exec ConsoleToMSBuild="True" Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)../tools/node_modules/@outsystems/ts2lang/ts2lang-main.js&quot; -l -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)../tools\ViewGenerator.js&quot;">
             <Output TaskParameter="ConsoleOutput" ItemName="VGC_Inputs"/>
         </Exec>
         <ItemGroup>
@@ -53,7 +53,7 @@
  
   <Target Name="VGC_GenerateViewInner" DependsOnTargets="VGC_CleanGenerated">
     <Message Importance="High" Text="Generating View files" />
-    <Exec Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;" />
+    <Exec Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)../tools/node_modules/@outsystems/ts2lang/ts2lang-main.js&quot; -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)../tools/ViewGenerator.js&quot;" />
 
     <Touch Files="VGC_Build.cache" AlwaysCreate="true" />
   </Target>

--- a/ViewGeneratorCore/build/ViewGeneratorCore.targets
+++ b/ViewGeneratorCore/build/ViewGeneratorCore.targets
@@ -1,42 +1,42 @@
 ﻿<Project>
+  <PropertyGroup>
+
+    <BuildDependsOn>
+      VGC_GenerateView;
+      $(BuildDependsOn)
+    </BuildDependsOn>
+
+    <CleanDependsOn>
+      VGC_CleanGenerated;
+      $(CleanDependsOn);
+    </CleanDependsOn>
+
+    <ViewGeneratorCorePath>$([System.IO.Path]::GetFullPath(&quot;$(MSBuildThisFileDirectory)..\&quot;))</ViewGeneratorCorePath>
+    <ViewGeneratorCoreContentFilesPath>$(ViewGeneratorCorePath)contentFiles\</ViewGeneratorCoreContentFilesPath>
+    <NodeVersion>12.18.4</NodeVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="**\*.cache"/>
+  </ItemGroup>
+
+  <Target Name="VGC_SetVariables">
+      <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+          <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\..\Node.js.redist\$(NodeVersion)\tools\win-x64\node.exe"/>
+          <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\Node.js.redist.$(NodeVersion)\tools\win-x64\node.exe"/>
+      </ItemGroup>
+      <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+          <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\..\Node.js.redist\$(NodeVersion)\tools\osx-x64\node"/>
+          <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\Node.js.redist.$(NodeVersion)\tools\osx-x64\node"/>
+      </ItemGroup>
+      <ItemGroup>
+          <_ViewGeneratorCoreNodeJsExeAfterCheckedPaths Include="@(_ViewGeneratorCoreNodeJsExe)" Condition="Exists('%(FullPath)')"  />
+      </ItemGroup>
     <PropertyGroup>
-
-        <BuildDependsOn>
-            VGC_GenerateView;
-            $(BuildDependsOn)
-        </BuildDependsOn>
-
-        <CleanDependsOn>
-            VGC_CleanGenerated;
-            $(CleanDependsOn);
-        </CleanDependsOn>
-
-        <ViewGeneratorCorePath>$([System.IO.Path]::GetFullPath(&quot;$(MSBuildThisFileDirectory)..\&quot;))</ViewGeneratorCorePath>
-        <ViewGeneratorCoreContentFilesPath>$(ViewGeneratorCorePath)contentFiles\</ViewGeneratorCoreContentFilesPath>
-        <NodeVersion>12.18.4</NodeVersion>
+      <__ViewGeneratorCoreNodeJsExe>@(_ViewGeneratorCoreNodeJsExeAfterCheckedPaths);</__ViewGeneratorCoreNodeJsExe>
+      <ViewGeneratorCoreNodeJsExe>$(__ViewGeneratorCoreNodeJsExe.Substring(0, $(__ViewGeneratorCoreNodeJsExe.IndexOf(';'))))</ViewGeneratorCoreNodeJsExe>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Remove="**\*.cache"/>
-    </ItemGroup>
-
-    <Target Name="VGC_SetVariables">
-        <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-            <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\..\Node.js.redist\$(NodeVersion)\tools\win-x64\node.exe"/>
-            <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\Node.js.redist.$(NodeVersion)\tools\win-x64\node.exe"/>
-        </ItemGroup>
-        <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
-            <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\..\Node.js.redist\$(NodeVersion)\tools\osx-x64\node"/>
-            <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\Node.js.redist.$(NodeVersion)\tools\osx-x64\node"/>
-        </ItemGroup>
-        <ItemGroup>
-            <_ViewGeneratorCoreNodeJsExeAfterCheckedPaths Include="@(_ViewGeneratorCoreNodeJsExe)" Condition="Exists('%(FullPath)')"  />
-        </ItemGroup>
-        <PropertyGroup>
-            <__ViewGeneratorCoreNodeJsExe>@(_ViewGeneratorCoreNodeJsExeAfterCheckedPaths);</__ViewGeneratorCoreNodeJsExe>
-            <ViewGeneratorCoreNodeJsExe>$(__ViewGeneratorCoreNodeJsExe.Substring(0, $(__ViewGeneratorCoreNodeJsExe.IndexOf(';'))))</ViewGeneratorCoreNodeJsExe>
-        </PropertyGroup>
-    </Target>
+  </Target>
 
     <Target Name="VGC_GetInputs" DependsOnTargets="VGC_SetVariables;VGC_Setup">
         <Exec ConsoleToMSBuild="True" Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -l -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;">
@@ -47,53 +47,52 @@
         </ItemGroup>
     </Target>
 
-    <Target Name="VGC_GenerateView" Inputs="@(VGC_Inputs)" Outputs="VGC_Build.cache" Condition="'$(UsingMicrosoftNETSdk)' != 'true' Or '$(DesignTimeBuild)' != 'true'" BeforeTargets="CustomTransformDuringBuild;TransformDuringBuild;AfterResolveReferences" DependsOnTargets="VGC_GetInputs">
-        <Message Text="@(VGC_Inputs)"></Message>
-        <CallTarget Targets="VGC_GenerateViewInner" />
-    </Target>
+  <Target Name="VGC_GenerateView" Inputs="@(VGC_Inputs)" Outputs="VGC_Build.cache" Condition="'$(UsingMicrosoftNETSdk)' != 'true' Or '$(DesignTimeBuild)' != 'true'" BeforeTargets="CustomTransformDuringBuild;TransformDuringBuild;AfterResolveReferences" DependsOnTargets="VGC_GetInputs">
+    <CallTarget Targets="VGC_GenerateViewInner" />
+  </Target>
+ 
+  <Target Name="VGC_GenerateViewInner" DependsOnTargets="VGC_CleanGenerated">
+    <Message Importance="High" Text="Generating View files" />
+    <Exec Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;" />
 
-    <Target Name="VGC_GenerateViewInner" DependsOnTargets="VGC_CleanGenerated">
-        <Message Importance="High" Text="Generating View files" />
-        <Exec Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;" />
+    <Touch Files="VGC_Build.cache" AlwaysCreate="true" />
+  </Target>
 
-        <Touch Files="VGC_Build.cache" AlwaysCreate="true" />
-    </Target>
-
-    <!-- old-format and new-format projects have different built-in targets. In order to support both we need to have two
+  <!-- old-format and new-format projects have different built-in targets. In order to support both we need to have two
        different alternative ways of adding the generated code to the target project :( -->
+       
+  <Target Name="VGC_IncludeGeneratedFiles_NonSdk" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Compile Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" Exclude="@(Compile)" />
+    </ItemGroup>
+  </Target>
 
-    <Target Name="VGC_IncludeGeneratedFiles_NonSdk" BeforeTargets="CoreCompile">
-        <ItemGroup>
-            <Compile Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" Exclude="@(Compile)" />
-        </ItemGroup>
-    </Target>
+  <Target Name="VGC_IncludeGeneratedFiles_Sdk" AfterTargets="VGC_GenerateView">
+    <ItemGroup>
+      <Compile Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" Exclude="@(Compile)" />
+    </ItemGroup>
+  </Target>
+  
+  <Target Name="VGC_CleanGenerated" BeforeTargets="Clean" >
+    <Error Condition="$(ViewGeneratorGeneratedFolder) == ''" Text="Generated folder is not set." />
 
-    <Target Name="VGC_IncludeGeneratedFiles_Sdk" AfterTargets="VGC_GenerateView">
-        <ItemGroup>
-            <Compile Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" Exclude="@(Compile)" />
-        </ItemGroup>
-    </Target>
+    <ItemGroup>
+      <GeneratedTs2LangFiles Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" />
+    </ItemGroup>
 
-    <Target Name="VGC_CleanGenerated" BeforeTargets="Clean" >
-        <Error Condition="$(ViewGeneratorGeneratedFolder) == ''" Text="Generated folder is not set." />
-
-        <ItemGroup>
-            <GeneratedTs2LangFiles Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" />
-        </ItemGroup>
-
-        <Delete Files="@(GeneratedTs2LangFiles)" />
-        <Delete Files="VGC_Build.cache" />
-    </Target>
+    <Delete Files="@(GeneratedTs2LangFiles)" />
+    <Delete Files="VGC_Build.cache" />
+  </Target>
 
 
-    <Target Name="VGC_Setup" DependsOnTargets="VGC_SetVariables" Condition="!Exists('$(ProjectDir)VGC.cache') OR $([System.IO.File]::GetLastWriteTime('$(ViewGeneratorCoreContentFilesPath)VGC.cache').Ticks) &gt; $([System.IO.File]::GetLastWriteTime('$(ProjectDir)VGC.cache').Ticks)">
-        <CreateItem Include="$(ViewGeneratorCoreContentFilesPath)VGC.cache">
-            <Output TaskParameter="Include" ItemName="CacheFile" />
-        </CreateItem>
+  <Target Name="VGC_Setup" DependsOnTargets="VGC_SetVariables" Condition="!Exists('$(ProjectDir)VGC.cache') OR $([System.IO.File]::GetLastWriteTime('$(ViewGeneratorCoreContentFilesPath)VGC.cache').Ticks) &gt; $([System.IO.File]::GetLastWriteTime('$(ProjectDir)VGC.cache').Ticks)">
+    <CreateItem Include="$(ViewGeneratorCoreContentFilesPath)VGC.cache">
+      <Output TaskParameter="Include" ItemName="CacheFile" />
+    </CreateItem>
 
-        <Copy SourceFiles="@(CacheFile)" DestinationFolder="$(ProjectDir)%(CacheFile.RecursiveDir)" />
+    <Copy SourceFiles="@(CacheFile)" DestinationFolder="$(ProjectDir)%(CacheFile.RecursiveDir)" />
 
-        <Delete Condition="Exists('$(ProjectDir)VGC_Build.cache')" Files="VGC_Build.cache" />
-    </Target>
+    <Delete Condition="Exists('$(ProjectDir)VGC_Build.cache')" Files="VGC_Build.cache" />
+  </Target>
 
 </Project>

--- a/ViewGeneratorCore/build/ViewGeneratorCore.targets
+++ b/ViewGeneratorCore/build/ViewGeneratorCore.targets
@@ -39,7 +39,7 @@
   </Target>
 
     <Target Name="VGC_GetInputs" DependsOnTargets="VGC_SetVariables;VGC_Setup">
-        <Exec ConsoleToMSBuild="True" Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)../tools/node_modules/@outsystems/ts2lang/ts2lang-main.js&quot; -l -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)../tools\ViewGenerator.js&quot;">
+        <Exec ConsoleToMSBuild="True" Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)../tools/node_modules/@outsystems/ts2lang/ts2lang-main.js&quot; -l -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)../tools/ViewGenerator.js&quot;">
             <Output TaskParameter="ConsoleOutput" ItemName="VGC_Inputs"/>
         </Exec>
         <ItemGroup>

--- a/ViewGeneratorCore/build/ViewGeneratorCore.targets
+++ b/ViewGeneratorCore/build/ViewGeneratorCore.targets
@@ -1,115 +1,99 @@
 ﻿<Project>
-  <PropertyGroup>
-
-    <BuildDependsOn>
-      VGC_GenerateView;
-      $(BuildDependsOn)
-    </BuildDependsOn>
-
-    <CleanDependsOn>
-      VGC_CleanGenerated;
-      $(CleanDependsOn);
-    </CleanDependsOn>
-
-    <ViewGeneratorCorePath>$([System.IO.Path]::GetFullPath(&quot;$(MSBuildThisFileDirectory)..\&quot;))</ViewGeneratorCorePath>
-    <ViewGeneratorCoreContentFilesPath>$(ViewGeneratorCorePath)contentFiles\</ViewGeneratorCoreContentFilesPath>
-    <NodeVersion>12.18.4</NodeVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="**\*.cache"/>
-  </ItemGroup>
-
-  <Target Name="VGC_SetVariables">
-      <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-          <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\..\Node.js.redist\$(NodeVersion)\tools\win-x64\node.exe"/>
-          <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\Node.js.redist.$(NodeVersion)\tools\win-x64\node.exe"/>
-      </ItemGroup>
-      <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
-          <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\..\Node.js.redist\$(NodeVersion)\tools\osx-x64\node"/>
-          <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\Node.js.redist.$(NodeVersion)\tools\osx-x64\node"/>
-      </ItemGroup>
-      <ItemGroup>
-          <_ViewGeneratorCoreNodeJsExeAfterCheckedPaths Include="@(_ViewGeneratorCoreNodeJsExe)" Condition="Exists('%(FullPath)')"  />
-      </ItemGroup>
     <PropertyGroup>
-      <__ViewGeneratorCoreNodeJsExe>@(_ViewGeneratorCoreNodeJsExeAfterCheckedPaths);</__ViewGeneratorCoreNodeJsExe>
-      <ViewGeneratorCoreNodeJsExe>$(__ViewGeneratorCoreNodeJsExe.Substring(0, $(__ViewGeneratorCoreNodeJsExe.IndexOf(';'))))</ViewGeneratorCoreNodeJsExe>
+
+        <BuildDependsOn>
+            VGC_GenerateView;
+            $(BuildDependsOn)
+        </BuildDependsOn>
+
+        <CleanDependsOn>
+            VGC_CleanGenerated;
+            $(CleanDependsOn);
+        </CleanDependsOn>
+
+        <ViewGeneratorCorePath>$([System.IO.Path]::GetFullPath(&quot;$(MSBuildThisFileDirectory)..\&quot;))</ViewGeneratorCorePath>
+        <ViewGeneratorCoreContentFilesPath>$(ViewGeneratorCorePath)contentFiles\</ViewGeneratorCoreContentFilesPath>
+        <NodeVersion>12.18.4</NodeVersion>
     </PropertyGroup>
 
-      <PropertyGroup>
-          <VGCInputConfigFilePattern>input&quot;.*:.*&quot;(.*)&quot;</VGCInputConfigFilePattern>
-      </PropertyGroup>
-
-      <ItemGroup>
-          <Ts2LangConfigFile Include="$(MSBuildProjectDirectory)\ts2lang.json" />
-      </ItemGroup>
-
-      <ReadLinesFromFile File="@(Ts2LangConfigFile)">
-          <Output TaskParameter="Lines" ItemName="Ts2LangConfigFileContents" />
-      </ReadLinesFromFile>
-
-      <ItemGroup>
-          <Config Include="$([System.Text.RegularExpressions.Regex]::Match('%(Ts2LangConfigFileContents.Identity)', $(VGCInputConfigFilePattern)).Groups[1].Value)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Ts2LangConfigFileContents.Identity)', $(VGCInputConfigFilePattern)))" />
-      </ItemGroup>
-
-      <CreateItem Include="%(Config.Identity)">
-          <Output
-              TaskParameter="Include"
-              ItemName="VGC_Inputs"/>
-      </CreateItem>
-  </Target>
-
     <ItemGroup>
-        <UpToDateCheckInput Include="@(VGC_Inputs)" Exclude="@(UpToDateCheckInput)" />
+        <None Remove="**\*.cache"/>
     </ItemGroup>
 
-  <Target Name="VGC_GenerateView" Inputs="@(VGC_Inputs)" Outputs="VGC_Build.cache" Condition="'$(UsingMicrosoftNETSdk)' != 'true' Or '$(DesignTimeBuild)' != 'true'" BeforeTargets="CustomTransformDuringBuild;TransformDuringBuild;AfterResolveReferences" DependsOnTargets="VGC_SetVariables;VGC_Setup">
-    <CallTarget Targets="VGC_GenerateViewInner" />
-  </Target>
- 
-  <Target Name="VGC_GenerateViewInner" DependsOnTargets="VGC_CleanGenerated">
-    <Message Importance="High" Text="Generating View files" />
-    <Exec Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;" />
+    <Target Name="VGC_SetVariables">
+        <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+            <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\..\Node.js.redist\$(NodeVersion)\tools\win-x64\node.exe"/>
+            <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\Node.js.redist.$(NodeVersion)\tools\win-x64\node.exe"/>
+        </ItemGroup>
+        <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+            <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\..\Node.js.redist\$(NodeVersion)\tools\osx-x64\node"/>
+            <_ViewGeneratorCoreNodeJsExe Include="$(MSBuildThisFileDirectory)..\..\Node.js.redist.$(NodeVersion)\tools\osx-x64\node"/>
+        </ItemGroup>
+        <ItemGroup>
+            <_ViewGeneratorCoreNodeJsExeAfterCheckedPaths Include="@(_ViewGeneratorCoreNodeJsExe)" Condition="Exists('%(FullPath)')"  />
+        </ItemGroup>
+        <PropertyGroup>
+            <__ViewGeneratorCoreNodeJsExe>@(_ViewGeneratorCoreNodeJsExeAfterCheckedPaths);</__ViewGeneratorCoreNodeJsExe>
+            <ViewGeneratorCoreNodeJsExe>$(__ViewGeneratorCoreNodeJsExe.Substring(0, $(__ViewGeneratorCoreNodeJsExe.IndexOf(';'))))</ViewGeneratorCoreNodeJsExe>
+        </PropertyGroup>
+    </Target>
 
-    <Touch Files="VGC_Build.cache" AlwaysCreate="true" />
-  </Target>
+    <Target Name="VGC_GetInputs" DependsOnTargets="VGC_SetVariables;VGC_Setup">
+        <Exec ConsoleToMSBuild="True" Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -l -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;">
+            <Output TaskParameter="ConsoleOutput" ItemName="VGC_Inputs"/>
+        </Exec>
+        <ItemGroup>
+            <UpToDateCheckInput Include="@(VGC_Inputs)" Exclude="@(UpToDateCheckInput)" />
+        </ItemGroup>
+    </Target>
 
-  <!-- old-format and new-format projects have different built-in targets. In order to support both we need to have two
+    <Target Name="VGC_GenerateView" Inputs="@(VGC_Inputs)" Outputs="VGC_Build.cache" Condition="'$(UsingMicrosoftNETSdk)' != 'true' Or '$(DesignTimeBuild)' != 'true'" BeforeTargets="CustomTransformDuringBuild;TransformDuringBuild;AfterResolveReferences" DependsOnTargets="VGC_GetInputs">
+        <Message Text="@(VGC_Inputs)"></Message>
+        <CallTarget Targets="VGC_GenerateViewInner" />
+    </Target>
+
+    <Target Name="VGC_GenerateViewInner" DependsOnTargets="VGC_CleanGenerated">
+        <Message Importance="High" Text="Generating View files" />
+        <Exec Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -f &quot;$(ProjectDir)ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;" />
+
+        <Touch Files="VGC_Build.cache" AlwaysCreate="true" />
+    </Target>
+
+    <!-- old-format and new-format projects have different built-in targets. In order to support both we need to have two
        different alternative ways of adding the generated code to the target project :( -->
-       
-  <Target Name="VGC_IncludeGeneratedFiles_NonSdk" BeforeTargets="CoreCompile">
-    <ItemGroup>
-      <Compile Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" Exclude="@(Compile)" />
-    </ItemGroup>
-  </Target>
 
-  <Target Name="VGC_IncludeGeneratedFiles_Sdk" AfterTargets="VGC_GenerateView">
-    <ItemGroup>
-      <Compile Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" Exclude="@(Compile)" />
-    </ItemGroup>
-  </Target>
-  
-  <Target Name="VGC_CleanGenerated" BeforeTargets="Clean" >
-    <Error Condition="$(ViewGeneratorGeneratedFolder) == ''" Text="Generated folder is not set." />
+    <Target Name="VGC_IncludeGeneratedFiles_NonSdk" BeforeTargets="CoreCompile">
+        <ItemGroup>
+            <Compile Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" Exclude="@(Compile)" />
+        </ItemGroup>
+    </Target>
 
-    <ItemGroup>
-      <GeneratedTs2LangFiles Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" />
-    </ItemGroup>
+    <Target Name="VGC_IncludeGeneratedFiles_Sdk" AfterTargets="VGC_GenerateView">
+        <ItemGroup>
+            <Compile Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" Exclude="@(Compile)" />
+        </ItemGroup>
+    </Target>
 
-    <Delete Files="@(GeneratedTs2LangFiles)" />
-    <Delete Files="VGC_Build.cache" />
-  </Target>
+    <Target Name="VGC_CleanGenerated" BeforeTargets="Clean" >
+        <Error Condition="$(ViewGeneratorGeneratedFolder) == ''" Text="Generated folder is not set." />
+
+        <ItemGroup>
+            <GeneratedTs2LangFiles Include="$(ViewGeneratorGeneratedFolder)\**\*.cs" />
+        </ItemGroup>
+
+        <Delete Files="@(GeneratedTs2LangFiles)" />
+        <Delete Files="VGC_Build.cache" />
+    </Target>
 
 
-  <Target Name="VGC_Setup" DependsOnTargets="VGC_SetVariables" Condition="!Exists('$(ProjectDir)VGC.cache') OR $([System.IO.File]::GetLastWriteTime('$(ViewGeneratorCoreContentFilesPath)VGC.cache').Ticks) &gt; $([System.IO.File]::GetLastWriteTime('$(ProjectDir)VGC.cache').Ticks)">
-    <CreateItem Include="$(ViewGeneratorCoreContentFilesPath)VGC.cache">
-      <Output TaskParameter="Include" ItemName="CacheFile" />
-    </CreateItem>
+    <Target Name="VGC_Setup" DependsOnTargets="VGC_SetVariables" Condition="!Exists('$(ProjectDir)VGC.cache') OR $([System.IO.File]::GetLastWriteTime('$(ViewGeneratorCoreContentFilesPath)VGC.cache').Ticks) &gt; $([System.IO.File]::GetLastWriteTime('$(ProjectDir)VGC.cache').Ticks)">
+        <CreateItem Include="$(ViewGeneratorCoreContentFilesPath)VGC.cache">
+            <Output TaskParameter="Include" ItemName="CacheFile" />
+        </CreateItem>
 
-    <Copy SourceFiles="@(CacheFile)" DestinationFolder="$(ProjectDir)%(CacheFile.RecursiveDir)" />
+        <Copy SourceFiles="@(CacheFile)" DestinationFolder="$(ProjectDir)%(CacheFile.RecursiveDir)" />
 
-    <Delete Condition="Exists('$(ProjectDir)VGC_Build.cache')" Files="VGC_Build.cache" />
-  </Target>
+        <Delete Condition="Exists('$(ProjectDir)VGC_Build.cache')" Files="VGC_Build.cache" />
+    </Target>
 
 </Project>

--- a/ViewGeneratorCore/build/ViewGeneratorCore.targets
+++ b/ViewGeneratorCore/build/ViewGeneratorCore.targets
@@ -39,7 +39,7 @@
   </Target>
 
   <ItemGroup>
-    <VGC_Inputs Include="$(OverrideProjectDir)**\*.tsx" Exclude="$(OverrideProjectDir)node_modules\**\*.tsx" />
+    <VGC_Inputs Include="$(OverrideProjectDir)**\*.view.tsx" Exclude="$(OverrideProjectDir)node_modules\**\*.tsx" />
     <VGC_Inputs Include="$(OverrideProjectDir)**\*.ts" Exclude="$(OverrideProjectDir)node_modules\**\*.ts" />
     <UpToDateCheckInput Include="@(VGC_Inputs)" Exclude="@(UpToDateCheckInput)" />
   </ItemGroup>

--- a/ViewGeneratorCore/build/ViewGeneratorCore.targets
+++ b/ViewGeneratorCore/build/ViewGeneratorCore.targets
@@ -36,13 +36,33 @@
       <__ViewGeneratorCoreNodeJsExe>@(_ViewGeneratorCoreNodeJsExeAfterCheckedPaths);</__ViewGeneratorCoreNodeJsExe>
       <ViewGeneratorCoreNodeJsExe>$(__ViewGeneratorCoreNodeJsExe.Substring(0, $(__ViewGeneratorCoreNodeJsExe.IndexOf(';'))))</ViewGeneratorCoreNodeJsExe>
     </PropertyGroup>
+
+      <PropertyGroup>
+          <VGCInputConfigFilePattern>input&quot;.*:.*&quot;(.*)&quot;</VGCInputConfigFilePattern>
+      </PropertyGroup>
+
+      <ItemGroup>
+          <Ts2LangConfigFile Include="$(MSBuildProjectDirectory)\ts2lang.json" />
+      </ItemGroup>
+
+      <ReadLinesFromFile File="@(Ts2LangConfigFile)">
+          <Output TaskParameter="Lines" ItemName="Ts2LangConfigFileContents" />
+      </ReadLinesFromFile>
+
+      <ItemGroup>
+          <Config Include="$([System.Text.RegularExpressions.Regex]::Match('%(Ts2LangConfigFileContents.Identity)', $(VGCInputConfigFilePattern)).Groups[1].Value)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(Ts2LangConfigFileContents.Identity)', $(VGCInputConfigFilePattern)))" />
+      </ItemGroup>
+
+      <CreateItem Include="%(Config.Identity)">
+          <Output
+              TaskParameter="Include"
+              ItemName="VGC_Inputs"/>
+      </CreateItem>
   </Target>
 
-  <ItemGroup>
-    <VGC_Inputs Include="$(OverrideProjectDir)**\*.view.tsx" Exclude="$(OverrideProjectDir)node_modules\**\*.tsx" />
-    <VGC_Inputs Include="$(OverrideProjectDir)**\*.ts" Exclude="$(OverrideProjectDir)node_modules\**\*.ts" />
-    <UpToDateCheckInput Include="@(VGC_Inputs)" Exclude="@(UpToDateCheckInput)" />
-  </ItemGroup>
+    <ItemGroup>
+        <UpToDateCheckInput Include="@(VGC_Inputs)" Exclude="@(UpToDateCheckInput)" />
+    </ItemGroup>
 
   <Target Name="VGC_GenerateView" Inputs="@(VGC_Inputs)" Outputs="VGC_Build.cache" Condition="'$(UsingMicrosoftNETSdk)' != 'true' Or '$(DesignTimeBuild)' != 'true'" BeforeTargets="CustomTransformDuringBuild;TransformDuringBuild;AfterResolveReferences" DependsOnTargets="VGC_SetVariables;VGC_Setup">
     <CallTarget Targets="VGC_GenerateViewInner" />

--- a/ViewGeneratorCore/tools/package-lock.json
+++ b/ViewGeneratorCore/tools/package-lock.json
@@ -3,30 +3,23 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@outsystems/ts2lang": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@outsystems/ts2lang/-/ts2lang-1.0.12.tgz",
-      "integrity": "sha512-M3Jw/aC78d4Rq2ym2lQy1Kdp5byLujOZqPO7I1E2wSdnyEC4UrJRSgcKxOznLM/nXvVdpP8+F8tDEzqT48q9zQ==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@outsystems/ts2lang/-/ts2lang-1.0.21.tgz",
+      "integrity": "sha512-K4v/hOvImzm/28ZpLZmiK3CRzdWm0SMJEN3mMbgKbj2rDAzLuAfE53RNE5DLAGoZGMeCrLkq6yuT9wLrAHANog==",
       "dev": true,
       "requires": {
+        "@outsystems/ts2lang": "^1.0.12",
         "commander": "^2.9.0",
         "glob": "^7.1.2",
         "is-directory": "^0.3.1",
         "merge": "^1.2.0",
-        "typescript": "2.6.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
-          "dev": true
-        }
+        "typescript": "3.4"
       }
     },
     "@types/node": {
-      "version": "12.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg=="
+      "version": "12.20.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
+      "integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -45,9 +38,9 @@
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "concat-map": {
@@ -63,9 +56,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -87,9 +80,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "is-directory": {
@@ -126,6 +119,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "wrappy": {

--- a/ViewGeneratorCore/tools/package.json
+++ b/ViewGeneratorCore/tools/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@outsystems/ts2lang": "1.0.12"
+    "@outsystems/ts2lang": "1.0.21"
   },
   "dependencies": {
     "@types/node": "^12.6.8"

--- a/ViewGeneratorCore/tools/tsconfig.json
+++ b/ViewGeneratorCore/tools/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"outDir": "dist",
 		"module": "commonjs",
-		"target": "es6",
+		"target": "ES2016",
 		"sourceMap": false,
 		"allowJs": true,
 		"moduleResolution": "node",


### PR DESCRIPTION
View Core Generation always runs if we change a `.tsx `or a `.view.tsx`.

With this fix it will only run if we change a `view.tsx`.