### PR TITLE
- Mac-Win path separator issue: Changed the way to get file name with…

### DIFF
--- a/ViewGenerator/ViewGenerator.csproj
+++ b/ViewGenerator/ViewGenerator.csproj
@@ -8,7 +8,7 @@
     <Product>ViewGenerator</Product>
     <Description>Generates .NET View bindings from typescript</Description>
     <Copyright>Copyright ©  2018</Copyright>
-    <Version>1.0.311</Version>
+    <Version>1.0.312</Version>
     <PackageId>ViewGenerator</PackageId>
     <Authors>OutSystems</Authors>
     <PackageTags>Library</PackageTags>

--- a/ViewGenerator/tools/webpack/webpack_stylesheets.config.ts
+++ b/ViewGenerator/tools/webpack/webpack_stylesheets.config.ts
@@ -12,8 +12,7 @@ import SassRuleSet from "./Rules/Sass";
 const config = (_, argv) => {
 
     const getEntryName = (entryPath: string): string => {
-        let fileExtensionLen: number = entryPath.length - entryPath.lastIndexOf(".");
-        return entryPath.slice(entryPath.lastIndexOf("\\") + 1, -fileExtensionLen);
+        return /[^\\\/]+(?=\.[\w]+$)|[^\\\/]+$/.exec(entryPath)[0];
     };
 
     let entries: string = argv.entryPath;

--- a/ViewGenerator/tools/webpack/webpack_stylesheets.config.ts
+++ b/ViewGenerator/tools/webpack/webpack_stylesheets.config.ts
@@ -12,7 +12,8 @@ import SassRuleSet from "./Rules/Sass";
 const config = (_, argv) => {
 
     const getEntryName = (entryPath: string): string => {
-        return /[^\\\/]+(?=\.[\w]+$)|[^\\\/]+$/.exec(entryPath)[0];
+        let fileExtensionLen: number = entryPath.length - entryPath.lastIndexOf(".");
+        return entryPath.slice(entryPath.replace(/\//g, '\\').lastIndexOf("\\") + 1, -fileExtensionLen);
     };
 
     let entries: string = argv.entryPath;


### PR DESCRIPTION
Changed the way webpack_stylesheets.config.ts getEntryName was resolved.
Previously code was trusting the last path separator (\) of a file path to get the "file_name_without_extension" 
Now code uses a regular expression that considers bot systems path separator.