### PR TITLE
Allow closing of hidden window in ReactView only when application has no more windows opened

### DIFF
--- a/ReactViewControl.Avalonia/ReactViewControl.Avalonia.csproj
+++ b/ReactViewControl.Avalonia/ReactViewControl.Avalonia.csproj
@@ -12,7 +12,7 @@
     <Product>ReactViewControl</Product>
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.85.22</Version>
+    <Version>2.85.23</Version>
     <PackageId>ReactViewControl-Avalonia</PackageId>
     <Authors>OutSystems</Authors>
     <PackageOutputPath>$(MSBuildProjectDirectory)\..\nuget</PackageOutputPath>

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -29,7 +29,7 @@ namespace ReactViewControl {
         }
 
         partial void PreloadWebView() {
-            var window = Host?.FindLogicalAncestorOfType<Window>() ?? GetHiddenWindow();
+            var window = Host?.FindLogicalAncestorOfType<WindowBase>() ?? GetHiddenWindow();
             // initialize browser with full screen size to avoid html measure issues on initial render
             var initialBrowserSizeWidth = (int)window.Screens.All.Max(s => s.WorkingArea.Width * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));
             var initialBrowserSizeHeight = (int)window.Screens.All.Max(s => s.WorkingArea.Height * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));
@@ -51,10 +51,6 @@ namespace ReactViewControl {
 
         private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {
             e.Cancel |= ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows.Count() != 0;
-            if (!e.Cancel) {
-                hiddenWindow.Closing -= OnHiddenWindowClosing;
-                hiddenWindow = null;
-            }
         }
 
         private static bool IsFrameworkAssemblyName(string name) {

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -1,66 +1,1 @@
-﻿using System.ComponentModel;
-using System.Linq;
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Input;
-using Avalonia.LogicalTree;
-
-namespace ReactViewControl {
-
-    partial class ReactViewRender : Control {
-
-        private static WindowBase hiddenWindow;
-
-        private static WindowBase GetHiddenWindow() {
-            if (hiddenWindow == null) {
-                hiddenWindow = new Window() {
-                    IsVisible = false,
-                    Focusable = false,
-                    Title = "Hidden React View Window"                    
-                };
-                ((Window)hiddenWindow).Closing += OnHiddenWindowClosing;
-            }
-            return hiddenWindow;
-        }
-
-        partial void ExtraInitialize() {
-            VisualChildren.Add(WebView);
-        }
-
-        partial void PreloadWebView() {
-            var window = Host?.FindLogicalAncestorOfType<WindowBase>() ?? GetHiddenWindow();
-            // initialize browser with full screen size to avoid html measure issues on initial render
-            var initialBrowserSizeWidth = (int)window.Screens.All.Max(s => s.WorkingArea.Width * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));
-            var initialBrowserSizeHeight = (int)window.Screens.All.Max(s => s.WorkingArea.Height * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));
-            WebView.InitializeBrowser(window, initialBrowserSizeWidth, initialBrowserSizeHeight);
-        }
-
-        protected override void OnGotFocus(GotFocusEventArgs e) {
-            e.Handled = true;
-            WebView.Focus();
-        }
-
-        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change) {
-            base.OnPropertyChanged(change);
-
-            if (!ExtendedWebView.Settings.OsrEnabled && change.Property == IsEffectivelyEnabledProperty) {
-                 DisableInputInteractions(!IsEffectivelyEnabled);
-            }
-        }
-
-        private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {
-            e.Cancel = true;
-            var appWindows = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows;
-            if (hiddenWindow != null && appWindows.Count() == 0) {
-                ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;
-                ((Window)hiddenWindow).Close();
-                hiddenWindow = null;
-            }
-        }
-
-        private static bool IsFrameworkAssemblyName(string name) {
-            return name.StartsWith("Avalonia") || name == "mscorlib";
-        }
-    }
-}
+﻿using System.ComponentModel;using System.Linq;using Avalonia;using Avalonia.Controls;using Avalonia.Controls.ApplicationLifetimes;using Avalonia.Input;using Avalonia.LogicalTree;namespace ReactViewControl {    partial class ReactViewRender : Control {        private static WindowBase hiddenWindow;        private static WindowBase GetHiddenWindow() {            if (hiddenWindow == null) {                hiddenWindow = new Window() {                    IsVisible = false,                    Focusable = false,                    Title = "Hidden React View Window"                                    };                ((Window)hiddenWindow).Closing += OnHiddenWindowClosing;            }            return hiddenWindow;        }        partial void ExtraInitialize() {            VisualChildren.Add(WebView);        }        partial void PreloadWebView() {            var window = Host?.FindLogicalAncestorOfType<WindowBase>() ?? GetHiddenWindow();            // initialize browser with full screen size to avoid html measure issues on initial render            var initialBrowserSizeWidth = (int)window.Screens.All.Max(s => s.WorkingArea.Width * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));            var initialBrowserSizeHeight = (int)window.Screens.All.Max(s => s.WorkingArea.Height * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));            WebView.InitializeBrowser(window, initialBrowserSizeWidth, initialBrowserSizeHeight);        }        protected override void OnGotFocus(GotFocusEventArgs e) {            e.Handled = true;            WebView.Focus();        }        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change) {            base.OnPropertyChanged(change);            if (!ExtendedWebView.Settings.OsrEnabled && change.Property == IsEffectivelyEnabledProperty) {                 DisableInputInteractions(!IsEffectivelyEnabled);            }        }        private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {            e.Cancel = true;            var appWindows = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows;            if (hiddenWindow != null && appWindows.Count() == 0) {                ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;                ((Window)hiddenWindow).Close();                hiddenWindow = null;            }        }        private static bool IsFrameworkAssemblyName(string name) {            return name.StartsWith("Avalonia") || name == "mscorlib";        }    }}

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -52,7 +52,7 @@ namespace ReactViewControl {
         private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {
             e.Cancel = true;
             var appWindows = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows;
-            if (hiddenWindow != null && appWindows.Count() == 0) {
+            if (appWindows.Count() == 0) {
                 ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;
                 ((Window)hiddenWindow).Close();
                 hiddenWindow = null;

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -17,7 +17,7 @@ namespace ReactViewControl {
                 hiddenWindow = new Window() {
                     IsVisible = false,
                     Focusable = false,
-                    Title = "Hidden React View Window"                    
+                    Title = "Hidden React View Window"
                 };
                 ((Window)hiddenWindow).Closing += OnHiddenWindowClosing;
             }

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -1,1 +1,66 @@
-﻿using System.ComponentModel;using System.Linq;using Avalonia;using Avalonia.Controls;using Avalonia.Controls.ApplicationLifetimes;using Avalonia.Input;using Avalonia.LogicalTree;namespace ReactViewControl {    partial class ReactViewRender : Control {        private static WindowBase hiddenWindow;        private static WindowBase GetHiddenWindow() {            if (hiddenWindow == null) {                hiddenWindow = new Window() {                    IsVisible = false,                    Focusable = false,                    Title = "Hidden React View Window"                                    };                ((Window)hiddenWindow).Closing += OnHiddenWindowClosing;            }            return hiddenWindow;        }        partial void ExtraInitialize() {            VisualChildren.Add(WebView);        }        partial void PreloadWebView() {            var window = Host?.FindLogicalAncestorOfType<WindowBase>() ?? GetHiddenWindow();            // initialize browser with full screen size to avoid html measure issues on initial render            var initialBrowserSizeWidth = (int)window.Screens.All.Max(s => s.WorkingArea.Width * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));            var initialBrowserSizeHeight = (int)window.Screens.All.Max(s => s.WorkingArea.Height * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));            WebView.InitializeBrowser(window, initialBrowserSizeWidth, initialBrowserSizeHeight);        }        protected override void OnGotFocus(GotFocusEventArgs e) {            e.Handled = true;            WebView.Focus();        }        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change) {            base.OnPropertyChanged(change);            if (!ExtendedWebView.Settings.OsrEnabled && change.Property == IsEffectivelyEnabledProperty) {                 DisableInputInteractions(!IsEffectivelyEnabled);            }        }        private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {            e.Cancel = true;            var appWindows = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows;            if (hiddenWindow != null && appWindows.Count() == 0) {                ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;                ((Window)hiddenWindow).Close();                hiddenWindow = null;            }        }        private static bool IsFrameworkAssemblyName(string name) {            return name.StartsWith("Avalonia") || name == "mscorlib";        }    }}
+﻿using System.ComponentModel;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input;
+using Avalonia.LogicalTree;
+
+namespace ReactViewControl {
+
+    partial class ReactViewRender : Control {
+
+        private static WindowBase hiddenWindow;
+
+        private static WindowBase GetHiddenWindow() {
+            if (hiddenWindow == null) {
+                hiddenWindow = new Window() {
+                    IsVisible = false,
+                    Focusable = false,
+                    Title = "Hidden React View Window"                    
+                };
+                ((Window)hiddenWindow).Closing += OnHiddenWindowClosing;
+            }
+            return hiddenWindow;
+        }
+
+        partial void ExtraInitialize() {
+            VisualChildren.Add(WebView);
+        }
+
+        partial void PreloadWebView() {
+            var window = Host?.FindLogicalAncestorOfType<WindowBase>() ?? GetHiddenWindow();
+            // initialize browser with full screen size to avoid html measure issues on initial render
+            var initialBrowserSizeWidth = (int)window.Screens.All.Max(s => s.WorkingArea.Width * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));
+            var initialBrowserSizeHeight = (int)window.Screens.All.Max(s => s.WorkingArea.Height * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));
+            WebView.InitializeBrowser(window, initialBrowserSizeWidth, initialBrowserSizeHeight);
+        }
+
+        protected override void OnGotFocus(GotFocusEventArgs e) {
+            e.Handled = true;
+            WebView.Focus();
+        }
+
+        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change) {
+            base.OnPropertyChanged(change);
+
+            if (!ExtendedWebView.Settings.OsrEnabled && change.Property == IsEffectivelyEnabledProperty) {
+                 DisableInputInteractions(!IsEffectivelyEnabled);
+            }
+        }
+
+        private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {
+            e.Cancel = true;
+            var appWindows = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows;
+            if (hiddenWindow != null && appWindows.Count() == 0) {
+                ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;
+                ((Window)hiddenWindow).Close();
+                hiddenWindow = null;
+            }
+        }
+
+        private static bool IsFrameworkAssemblyName(string name) {
+            return name.StartsWith("Avalonia") || name == "mscorlib";
+        }
+    }
+}

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
@@ -10,16 +11,16 @@ namespace ReactViewControl {
 
     partial class ReactViewRender : Control {
 
-        private static WindowBase hiddenWindow;
+        private static Window hiddenWindow;
 
-        private static WindowBase GetHiddenWindow() {
+        private static Window GetHiddenWindow() {
             if (hiddenWindow == null) {
                 hiddenWindow = new Window() {
                     IsVisible = false,
                     Focusable = false,
                     Title = "Hidden React View Window"
                 };
-                ((Window)hiddenWindow).Closing += OnHiddenWindowClosing;
+                hiddenWindow.Closing += OnHiddenWindowClosing;
             }
             return hiddenWindow;
         }
@@ -29,7 +30,7 @@ namespace ReactViewControl {
         }
 
         partial void PreloadWebView() {
-            var window = Host?.FindLogicalAncestorOfType<WindowBase>() ?? GetHiddenWindow();
+            var window = Host?.FindLogicalAncestorOfType<Window>() ?? GetHiddenWindow();
             // initialize browser with full screen size to avoid html measure issues on initial render
             var initialBrowserSizeWidth = (int)window.Screens.All.Max(s => s.WorkingArea.Width * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));
             var initialBrowserSizeHeight = (int)window.Screens.All.Max(s => s.WorkingArea.Height * (ExtendedWebView.Settings.OsrEnabled ? 1 : s.PixelDensity));
@@ -52,7 +53,7 @@ namespace ReactViewControl {
         private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {
             e.Cancel |= ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows.Count() != 0;
             if (!e.Cancel) {
-                ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;
+                hiddenWindow.Closing -= OnHiddenWindowClosing;
                 hiddenWindow = null;
             }
         }

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -50,11 +50,9 @@ namespace ReactViewControl {
         }
 
         private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {
-            e.Cancel = true;
-            var appWindows = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows;
-            if (appWindows.Count() == 0) {
+            e.Cancel |= ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows.Count() == 0;
+            if (!e.Cancel) {
                 ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;
-                ((Window)hiddenWindow).Close();
                 hiddenWindow = null;
             }
         }

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -50,7 +50,7 @@ namespace ReactViewControl {
         }
 
         private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {
-            e.Cancel |= ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows.Count() == 0;
+            e.Cancel |= ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows.Count() != 0;
             if (!e.Cancel) {
                 ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;
                 hiddenWindow = null;

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -1,6 +1,8 @@
-﻿using System.Linq;
+﻿using System.ComponentModel;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 
@@ -15,8 +17,9 @@ namespace ReactViewControl {
                 hiddenWindow = new Window() {
                     IsVisible = false,
                     Focusable = false,
-                    Title = "Hidden React View Window"
+                    Title = "Hidden React View Window"                    
                 };
+                ((Window)hiddenWindow).Closing += OnHiddenWindowClosing;
             }
             return hiddenWindow;
         }
@@ -43,6 +46,16 @@ namespace ReactViewControl {
 
             if (!ExtendedWebView.Settings.OsrEnabled && change.Property == IsEffectivelyEnabledProperty) {
                  DisableInputInteractions(!IsEffectivelyEnabled);
+            }
+        }
+
+        private static void OnHiddenWindowClosing(object sender, CancelEventArgs e) {
+            e.Cancel = true;
+            var appWindows = ((IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime).Windows;
+            if (hiddenWindow != null && appWindows.Count() == 0) {
+                ((Window)hiddenWindow).Closing -= OnHiddenWindowClosing;
+                ((Window)hiddenWindow).Close();
+                hiddenWindow = null;
             }
         }
 

--- a/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
+++ b/ReactViewControl.Avalonia/ReactViewRender.Avalonia.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;


### PR DESCRIPTION
All Window object trigger Closing event on CMD + Q click. We shouldn't close hidden react window unless application was closed