### PR TITLE
Generate xmldoc comments from jsdoc comments

### DIFF
--- a/Example.Avalonia/Example.Avalonia.csproj
+++ b/Example.Avalonia/Example.Avalonia.csproj
@@ -32,7 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ViewGeneratorCore" Version="1.0.224">
+    <PackageReference Include="ViewGeneratorCore" Version="1.0.227">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Example.Avalonia/ExampleView/ExampleView.tsx
+++ b/Example.Avalonia/ExampleView/ExampleView.tsx
@@ -7,25 +7,35 @@ import * as Image from "./beach.jpg";
 import { ResourceLoader } from "ResourceLoader";
 import SubExampleView from "./SubExampleView";
 
+/** complex type */
 export interface ISomeType {
     name: string;
 }
 
+/** enum type */
 export enum ImageKind {
     None,
     Beach
 }
 
+/** interface with API for JS to call, to be handled by .NET */
 export interface IExampleViewProperties {
     click(arg: ISomeType): void;
+    /**
+     * a call that .NET handles
+     * and yields a result
+     * */
     getTime(): Promise<string>;
+    /** a call that .NET handles */
     viewMounted(): void;
     inputChanged(): void;
     readonly constantMessage: string;
     readonly image: ImageKind;
 }
 
+/** interface that JS exposes to .NET */
 export interface IExampleViewBehaviors {
+    /** call that JS handles from .NET */
     callMe(): void;
 }
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,7 @@
 		<add key="automatic" value="True" />
 	</packageRestore>
   <packageSources>
+    <add key="LocalBuilds" value="nuget" />
     <add key="Azure" value="https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/nuget/v3/index.json"/>
   </packageSources>
 </configuration>

--- a/ViewGenerator/ViewGenerator.csproj
+++ b/ViewGenerator/ViewGenerator.csproj
@@ -8,7 +8,7 @@
     <Product>ViewGenerator</Product>
     <Description>Generates .NET View bindings from typescript</Description>
     <Copyright>Copyright ©  2018</Copyright>
-    <Version>1.0.320</Version>
+    <Version>1.0.321</Version>
     <PackageId>ViewGenerator</PackageId>
     <Authors>OutSystems</Authors>
     <PackageTags>Library</PackageTags>
@@ -41,7 +41,7 @@
     <Touch Files="$(ProjectDir)contentFiles\VG.cache" AlwaysCreate="true" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.6.0">
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.3.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/ViewGeneratorCore/ViewGeneratorCore.csproj
+++ b/ViewGeneratorCore/ViewGeneratorCore.csproj
@@ -8,7 +8,7 @@
     <Product>ViewGeneratorCore</Product>
     <Description>Generates .NET View bindings from typescript</Description>
     <Copyright>Copyright ©  2019</Copyright>
-    <Version>1.0.226</Version>
+    <Version>1.0.227</Version>
     <PackageId>ViewGeneratorCore</PackageId>
     <Authors>OutSystems</Authors>
     <PackageTags>Library</PackageTags>
@@ -41,7 +41,7 @@
     <Touch Files="$(ProjectDir)contentFiles\VGC.cache" AlwaysCreate="true" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.6.0">
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.3.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/ViewGeneratorCore/tools/package-lock.json
+++ b/ViewGeneratorCore/tools/package-lock.json
@@ -3,28 +3,26 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@outsystems/ts2lang": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@outsystems/ts2lang/-/ts2lang-1.0.21.tgz",
-      "integrity": "sha512-K4v/hOvImzm/28ZpLZmiK3CRzdWm0SMJEN3mMbgKbj2rDAzLuAfE53RNE5DLAGoZGMeCrLkq6yuT9wLrAHANog==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@outsystems/ts2lang/-/ts2lang-1.1.1.tgz",
+      "integrity": "sha512-2wsWER8dZOt3SdRsiuiT2FhjVrDwF5iO2lX2+7SZ0jAJ8lUtpb1LYhG0lp9sXturZJBxbQfZ/gFrXe+cs4jzCA==",
       "dev": true,
       "requires": {
-        "@outsystems/ts2lang": "^1.0.12",
         "commander": "^2.9.0",
         "glob": "^7.1.2",
         "is-directory": "^0.3.1",
-        "merge": "^1.2.0",
-        "typescript": "3.4"
+        "typescript": "^4.1.3"
       }
     },
     "@types/node": {
-      "version": "12.20.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
-      "integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
+      "version": "12.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg=="
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "brace-expansion": {
@@ -56,9 +54,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -91,12 +89,6 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
-    "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -122,9 +114,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "wrappy": {

--- a/ViewGeneratorCore/tools/package.json
+++ b/ViewGeneratorCore/tools/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@outsystems/ts2lang": "1.0.21"
+    "@outsystems/ts2lang": "^1.1.1"
   },
   "dependencies": {
     "@types/node": "^12.6.8"

--- a/ViewPacker/tools/package-lock.json
+++ b/ViewPacker/tools/package-lock.json
@@ -5878,9 +5878,9 @@
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "typescript": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
-            "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ=="
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+            "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew=="
         },
         "unbox-primitive": {
             "version": "1.0.0",

--- a/ViewPacker/tools/package.json
+++ b/ViewPacker/tools/package.json
@@ -24,7 +24,7 @@
         "sass-loader": "^7.3.1",
         "thread-loader": "^2.1.3",
         "ts-loader": "^6.2.2",
-        "typescript": "^4.2.2",
+        "typescript": "^4.3.4",
         "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12",
         "webpack-dev-server": "^3.10.3",


### PR DESCRIPTION
This PR is leverages the change in OutSystems/ts2lang#9 and uses the provided jsDoc comments in the typescript files to generate matching xmldoc comments in the .NET code. This enables projects using ViewGeneratorCore to have proper IDE tooltips while in the .NET side.

ViewGenerator and ViewGeneratorCore versions are raised to allow a new release.