### PR TITLE
RMAC-7234 - Add support for images in web-components

### DIFF
--- a/ViewGenerator/ViewGenerator.csproj
+++ b/ViewGenerator/ViewGenerator.csproj
@@ -8,7 +8,7 @@
     <Product>ViewGenerator</Product>
     <Description>Generates .NET View bindings from typescript</Description>
     <Copyright>Copyright ©  2018</Copyright>
-    <Version>1.0.320</Version>
+    <Version>1.0.321</Version>
     <PackageId>ViewGenerator</PackageId>
     <Authors>OutSystems</Authors>
     <PackageTags>Library</PackageTags>

--- a/ViewGenerator/tools/webpack/Rules/Files.ts
+++ b/ViewGenerator/tools/webpack/Rules/Files.ts
@@ -24,14 +24,15 @@ const getResourcesRuleSet = (assemblyName?: string, pluginsBase? : string): Rule
                         // Context represents the path of the project being built by webpack, e.g. "C:\Git\Path\to\Project\"
                         //
                         const buildUrl = (url: string, resourceBase: string): string => {
-                            let isWebComponentsPackage = false;
+                            const PackagesFolder = "/packages/";
+                            let isOutSystemsWebPackage = false;
                             let idx: number = url.indexOf(`/${resourceBase}/`);
                             if (idx < 0 && pluginsBase) {                       
                                 idx = url.indexOf(`/${pluginsBase}/`);
-                            } else if (idx < 0 && url.indexOf("/packages/") > 0) {
-                                // web-components packages
+                            } else if (idx < 0 && url.indexOf(PackagesFolder) > 0) {
+                                // OutSystems web components packages
                                 idx = url.indexOf(`${url}`);
-                                isWebComponentsPackage = true;
+                                isOutSystemsWebPackage = true;
                             }
 
                             // relative paths starting with ".." are replaced by "_"
@@ -42,8 +43,9 @@ const getResourcesRuleSet = (assemblyName?: string, pluginsBase? : string): Rule
                                 }
 
                                 // URL (argument) is a relative path and contains the resource base path or the plugin assembly in its content
-                                if(isWebComponentsPackage) {
-                                    return "../node_modules/webview.plugins/@outsystems/web-" + url.substring(url.indexOf("/packages/") + "/packages/".length);
+                                if(isOutSystemsWebPackage) {
+                                    let packg = url.substring(url.indexOf(PackagesFolder) + PackagesFolder.length);
+                                    return `/${pluginsBase}/node_modules/@outsystems/web-${packg}`;
                                 } else {
                                     return url.substring(idx);
                                 }

--- a/ViewGenerator/tools/webpack/Rules/Files.ts
+++ b/ViewGenerator/tools/webpack/Rules/Files.ts
@@ -24,10 +24,14 @@ const getResourcesRuleSet = (assemblyName?: string, pluginsBase? : string): Rule
                         // Context represents the path of the project being built by webpack, e.g. "C:\Git\Path\to\Project\"
                         //
                         const buildUrl = (url: string, resourceBase: string): string => {
-
+                            let isWebComponentsPackage = false;
                             let idx: number = url.indexOf(`/${resourceBase}/`);
                             if (idx < 0 && pluginsBase) {                       
                                 idx = url.indexOf(`/${pluginsBase}/`);
+                            } else if (idx < 0 && url.indexOf("/packages/") > 0) {
+                                // web-components packages
+                                idx = url.indexOf(`${url}`);
+                                isWebComponentsPackage = true;
                             }
 
                             // relative paths starting with ".." are replaced by "_"
@@ -38,7 +42,11 @@ const getResourcesRuleSet = (assemblyName?: string, pluginsBase? : string): Rule
                                 }
 
                                 // URL (argument) is a relative path and contains the resource base path or the plugin assembly in its content
-                                return url.substring(idx);
+                                if(isWebComponentsPackage) {
+                                    return "../node_modules/webview.plugins/@outsystems/web-" + url.substring(url.indexOf("/packages/") + "/packages/".length);
+                                } else {
+                                    return url.substring(idx);
+                                }
                             }
 
                             if (idx >= 0) {

--- a/ViewGenerator/tools/webpack/Rules/Files.ts
+++ b/ViewGenerator/tools/webpack/Rules/Files.ts
@@ -23,6 +23,40 @@ const getResourcesRuleSet = (assemblyName?: string, pluginsBase? : string): Rule
                         //
                         // Context represents the path of the project being built by webpack, e.g. "C:\Git\Path\to\Project\"
                         //
+                        const PackagesFolder = "/packages/";
+                        const isOutSystemsPackagesWithOldNaming = (url) => {
+                            // means that the package name is (example) "web_feedback-message" or "web_image" instead of "web-feedback-message" or "web-image"
+                            const OutSystemsPackagesWithOldNaming = [
+                                "/carousel/",
+                                "/checkbox/",
+                                "/collapsible/",
+                                "/common/",
+                                "/editable-label/",
+                                "/feedback-message/",
+                                "/image/",
+                                "/input/",
+                                "/loading-legacy/",
+                                "/loading-wheel/",
+                                "/navigation-bar/",
+                                "/optioncards/",
+                                "/overlay/",
+                                "/progressbar/",
+                                "/radio-button/",
+                                "/slider/",
+                                "/splitter/",
+                                "/tabs/",
+                                "/theme/",
+                                "/theme-provider/",
+                                "/toggle/",
+                            ];
+
+                            for(var i = 0; i < OutSystemsPackagesWithOldNaming.length; ++i) {
+                                if(url.indexOf(OutSystemsPackagesWithOldNaming[i]) > 0) {
+                                    return true;
+                                }
+                            }
+                            return false;
+                        }
                         const buildUrl = (url: string, resourceBase: string): string => {
                             const PackagesFolder = "/packages/";
                             let isOutSystemsWebPackage = false;
@@ -45,7 +79,7 @@ const getResourcesRuleSet = (assemblyName?: string, pluginsBase? : string): Rule
                                 // URL (argument) is a relative path and contains the resource base path or the plugin assembly in its content
                                 if(isOutSystemsWebPackage) {
                                     let packg = url.substring(url.indexOf(PackagesFolder) + PackagesFolder.length);
-                                    return `/${pluginsBase}/node_modules/@outsystems/web-${packg}`;
+                                    return `/${pluginsBase}/node_modules/@outsystems/web${(isOutSystemsPackagesWithOldNaming(url)) ? "_" : "-"}${packg}`;
                                 } else {
                                     return url.substring(idx);
                                 }


### PR DESCRIPTION
In order to have images as resources in the web-components, we need to set the correct URLs.