### PR TITLE
Uses ordinal string compare instead of invariant culture

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.91.6</Version>
+    <Version>2.91.7</Version>
     <Authors>OutSystems</Authors>
     <Product>ReactView</Product>
     <Copyright>Copyright © OutSystems 2021</Copyright>

--- a/ReactViewControl/ReactViewRender.cs
+++ b/ReactViewControl/ReactViewRender.cs
@@ -421,7 +421,7 @@ namespace ReactViewControl {
         /// </summary>
         /// <param name="request"></param>
         private void OnWebViewBeforeNavigate(Request request) {
-            if (request.IsMainFrame && !request.Url.InvariantStartsWith($"{ResourceUrl.EmbeddedScheme}{Uri.SchemeDelimiter}")) {
+            if (request.IsMainFrame && !request.Url.StartsWithOrdinal($"{ResourceUrl.EmbeddedScheme}{Uri.SchemeDelimiter}")) {
                 UrlHelper.OpenInExternalBrowser(request.Url);
                 request.Cancel();
             }
@@ -433,7 +433,7 @@ namespace ReactViewControl {
         /// <param name="resourceHandler"></param>
         private void OnWebViewBeforeResourceLoad(ResourceHandler resourceHandler) {
             var url = resourceHandler.Url;
-            var scheme = url.Substring(0, Math.Max(0, url.InvariantIndexOf(Uri.SchemeDelimiter)));
+            var scheme = url.Substring(0, Math.Max(0, url.IndexOfOrdinal(Uri.SchemeDelimiter)));
 
             switch (scheme.ToLowerInvariant()) {
                 case ResourceUrl.CustomScheme:
@@ -551,9 +551,9 @@ namespace ReactViewControl {
         /// <param name="url"></param>
         /// <returns></returns>
         private string ToFullUrl(string url) {
-            if (url.InvariantContains(Uri.SchemeDelimiter)) {
+            if (url.ContainsOrdinal(Uri.SchemeDelimiter)) {
                 return url;
-            } else if (url.InvariantStartsWith(ResourceUrl.PathSeparator)) {
+            } else if (url.StartsWithOrdinal(ResourceUrl.PathSeparator)) {
                 if (IsHotReloadEnabled) {
                     return new Uri(DevServerUri, url).ToString();
                 } else {

--- a/ReactViewControl/StringExtensions.cs
+++ b/ReactViewControl/StringExtensions.cs
@@ -3,11 +3,11 @@ using System.Globalization;
 
 namespace ReactViewControl {
 
-    internal static class StringExtensions {
-        public static bool InvariantContains(this string str, string value) => str.IndexOf(value, 0, StringComparison.InvariantCulture) > -1;
+      internal static class StringExtensions {
+        public static bool ContainsOrdinal(this string str, string value) => str.IndexOf(value, 0, StringComparison.Ordinal) > -1;
 
-        public static bool InvariantStartsWith(this string str, string value) => str.StartsWith(value, false, CultureInfo.InvariantCulture);
+        public static bool StartsWithOrdinal(this string str, string value) => str.StartsWith(value, StringComparison.Ordinal);
 
-        public static int InvariantIndexOf(this string str, string value) => str.IndexOf(value, 0, StringComparison.InvariantCulture);
+        public static int IndexOfOrdinal(this string str, string value) => str.IndexOf(value, 0, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
After reading string comparison best practices in this [article](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings?redirectedfrom=MSDN#ordinal-string-operations). It is best suited for us to use Ordinal String comparison.

> Specifying the [StringComparison.Ordinal](https://docs.microsoft.com/en-us/dotnet/api/system.stringcomparison#system-stringcomparison-ordinal) or [StringComparison.OrdinalIgnoreCase](https://docs.microsoft.com/en-us/dotnet/api/system.stringcomparison#system-stringcomparison-ordinalignorecase) value in a method call signifies a non-linguistic comparison in which the features of natural languages are ignored. Methods that are invoked with these [StringComparison](https://docs.microsoft.com/en-us/dotnet/api/system.stringcomparison) values base string operation decisions on simple byte comparisons instead of casing or equivalence tables that are parameterized by culture. In most cases, this approach best fits the intended interpretation of strings while making code faster and more reliable.
