### PR TITLE
RIMPT-2709 Generate C# for a view with no functions

### DIFF
--- a/ViewGeneratorCore/tools/src/ViewGenerator.ts
+++ b/ViewGeneratorCore/tools/src/ViewGenerator.ts
@@ -324,8 +324,7 @@ class Generator {
     }
 
     public generateComponent(emitComponentClass: boolean, emitComponentInterface: boolean, emitComponentAdapter: boolean, emitViewObjects: boolean) {
-        if (!((this.component && this.behaviorsInterface && this.behaviorsInterface.functions.length > 0) ||
-            (this.propsInterface && this.propsInterface.functions.length > 0))) {
+        if (!this.component) {
             return "";
         }
 

--- a/ViewGeneratorCore/tools/src/ViewGenerator.ts
+++ b/ViewGeneratorCore/tools/src/ViewGenerator.ts
@@ -252,6 +252,30 @@ class Generator {
 
         const partialInitializeMethodName = `Initialize${this.componentName}`;
 
+        const generateEventsProperty = () => {
+            if (this.propsInterface && this.propsInterface.functions.length > 0) {
+                return `protected override string[] Events => new string[] { ${this.propsInterface.functions.map(p => `"${p.name}"`).join(",")} };`;
+            }
+
+            return "";
+        };
+
+        const generatePropertiesValuesProperty = () => {
+            if (this.propsInterface && this.propsInterface.properties.length > 0) {
+                return (
+                    `protected override ${keyValuePairType}[] PropertiesValues {\n` +
+                    `        get { \n` +
+                    `            return new ${keyValuePairType}[] {\n` +
+                    `    ${f(this.propsInterface.properties.map(p => `            new ${keyValuePairType}("${p.name}", ${toPascalCase(p.name)})`).join(",\n"))}\n` +
+                    `            };\n` +
+                    `        }\n` +
+                    `    }\n`
+                );
+            }
+
+            return "";
+        };
+
         const generateComponentClass = () => {
             return (
                 `public partial class ${this.componentName} : ${BaseComponentAliasName}, I${this.moduleName} {\n` +
@@ -280,18 +304,8 @@ class Generator {
             `    protected override string NativeObjectName => \"${this.propsInterfaceCoreName}\";\n` +
             `    protected override string ModuleName => \"${this.filename}\";\n` +
             `    protected override object CreateNativeObject() => new ${PropertiesClassName}(this);\n` +
-            `${this.propsInterface && this.propsInterface.functions.length > 0
-                ? `    protected override string[] Events => new string[] { ${this.propsInterface.functions.map(p => `"${p.name}"`).join(",")} };\n`
-                : ``}` +
-            `${this.propsInterface && this.propsInterface.properties.length > 0
-                ? `    protected override ${keyValuePairType}[] PropertiesValues {\n` +
-                `        get { \n` +
-                `            return new ${keyValuePairType}[] {\n` +
-                `    ${f(this.propsInterface.properties.map(p => `            new ${keyValuePairType}("${p.name}", ${toPascalCase(p.name)})`).join(",\n")) }\n` +
-                `            };\n` +
-                `        }\n` +
-                `    }\n`
-                : ``}` +
+            `    ${generateEventsProperty()}\n` +
+            `    ${generatePropertiesValuesProperty()}\n` +
             `    #if DEBUG\n` +
             `    protected override string Source => \"${this.fullPath}\";\n` +
             `    #endif\n` +

--- a/ViewGeneratorCore/tools/src/ViewGenerator.ts
+++ b/ViewGeneratorCore/tools/src/ViewGenerator.ts
@@ -130,7 +130,7 @@ class Generator {
             `    protected ${this.moduleName} Owner { get; }\n` +
             `    public ${PropertiesClassName}(${this.moduleName} owner) => ${ownerPropertyName} = owner;\n` +
             `    ${f(this.propsInterface ? (this.propsInterface.functions.length > 0 ? this.propsInterface.functions.map(f => generateNativeApiMethod(f)).join("\n") : "// the interface does not contain methods") : "")}\n` +
-            `}\n`
+            `}`
         );
     }
 
@@ -177,7 +177,7 @@ class Generator {
             this.propsInterface ? this.propsInterface.functions.map(generatePropertyEvent).concat(this.propsInterface.properties.map(generateProperty)) : [])
             .concat(this.behaviorsInterface ? this.behaviorsInterface.functions.map(generateBehaviorMethod) : [])
             .concat(this.childViewsInterface ? this.childViewsInterface.properties.map(generateChildViewProperty) : [])
-            .join("\n") + "\n";
+            .join("\n");
     }
 
     private generateComponentWrapperBody(hostPropertyName: string) {
@@ -273,7 +273,9 @@ class Generator {
             `public partial class ${this.moduleName} : ${BaseModuleAliasName}, I${this.moduleName} {\n` +
             `    \n` +
             `    ${f(this.generateNativeApi())}\n` +
+            `    \n` +
             `    ${f(this.generateComponentBody(generatePropertyEvent, generateProperty, generateBehaviorMethod, generateChildViewProperty))}\n` +
+            `    \n` +
             `    protected override string MainJsSource => \"${this.relativePath}\";\n` +
             `    protected override string NativeObjectName => \"${this.propsInterfaceCoreName}\";\n` +
             `    protected override string ModuleName => \"${this.filename}\";\n` +

--- a/ViewGeneratorCore/tools/src/ViewGenerator.ts
+++ b/ViewGeneratorCore/tools/src/ViewGenerator.ts
@@ -324,7 +324,8 @@ class Generator {
     }
 
     public generateComponent(emitComponentClass: boolean, emitComponentInterface: boolean, emitComponentAdapter: boolean, emitViewObjects: boolean) {
-        if (!this.component) {
+        if (!((this.component && this.behaviorsInterface && this.behaviorsInterface.functions.length > 0) ||
+            (this.propsInterface && this.propsInterface.functions.length > 0))) {
             return "";
         }
 


### PR DESCRIPTION
Currently, the ViewGenerator does not generate C# code for a view that does not have any functions in the properties interface.
We've now come across the need of having views in such conditions, or even with no properties interface at all.

This PR aims at adapting the conditions that prevent the view from being generated.