### PR TITLE
RDPMBT-1433 - Change message to open dev tools

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.91.7</Version>
+    <Version>2.91.8</Version>
     <Authors>OutSystems</Authors>
     <Product>ReactView</Product>
     <Copyright>Copyright © OutSystems 2021</Copyright>

--- a/ReactViewControl/ReactViewRender.LoaderModule.cs
+++ b/ReactViewControl/ReactViewRender.LoaderModule.cs
@@ -93,7 +93,7 @@ namespace ReactViewControl {
             /// </summary>
             /// <param name="url"></param>
             public void ShowResourceLoadFailedMessage(string url) {
-                ShowErrorMessage($"Failed to load resource '{url}'. Press F12 to open developer tools and see more details.");
+                ShowErrorMessage($"Failed to load resource '{url}'. Open developer tools and see more details.");
             }
 
             /// <summary>

--- a/ReactViewControl/ReactViewRender.LoaderModule.cs
+++ b/ReactViewControl/ReactViewRender.LoaderModule.cs
@@ -93,7 +93,7 @@ namespace ReactViewControl {
             /// </summary>
             /// <param name="url"></param>
             public void ShowResourceLoadFailedMessage(string url) {
-                ShowErrorMessage($"Failed to load resource '{url}'. Open developer tools and see more details.");
+                ShowErrorMessage($"Failed to load resource '{url}'. Open developer tools to see more details.");
             }
 
             /// <summary>


### PR DESCRIPTION
In the context of changing the shortcut to open developer tools, this needs to be changed. My suggestion is to remove the specific shortcut from the message. The shortcut will depend on the consumer of this library.
![image](https://user-images.githubusercontent.com/1200312/182858279-3b97fae3-5598-497a-9167-3f483716092e.png)