### PR TITLE
RDEV-6978 Fix Crash when webview is not yet added to visual tree

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Platforms>x64;ARM64</Platforms>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.120.102</Version>
+    <Version>2.120.103</Version>
     <Authors>OutSystems</Authors>
     <Product>ReactView</Product>
     <Copyright>Copyright © OutSystems 2023</Copyright>
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <AvaloniaVersion>11.0.9</AvaloniaVersion>
-    <WebViewVersion>2.121.101</WebViewVersion>
+    <WebViewVersion>2.121.102</WebViewVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)' == '' or '$(Platform)' == 'x64'">


### PR DESCRIPTION
Fix Crash when webview is not yet added to visual tree