### PR TITLE
Added app manifest

### DIFF
--- a/Sample.Avalonia/Sample.Avalonia.csproj
+++ b/Sample.Avalonia/Sample.Avalonia.csproj
@@ -6,6 +6,7 @@
     <RollForward>LatestMajor</RollForward>
     <Configurations>Debug;Release;ReleaseAvalonia;ReleaseWPF</Configurations>
     <RuntimeIdentifiers>osx-x64;win-x64;osx-arm64;win-arm64</RuntimeIdentifiers>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sample.Avalonia/app.manifest
+++ b/Sample.Avalonia/app.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
Fixes initialization error in windows

Without app manifest we run into the following error on startup:

> System.InvalidOperationException: "Unable to create child window for native control host. Application manifest with supported OS list might be required."

This started happening since avalonia upgrade and should only affect windows.