### PR TITLE
Increase stack size in windows OS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Platforms>x64;ARM64</Platforms>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
-    <Version>3.120.4</Version>
+    <Version>3.120.7</Version>
     <Authors>OutSystems</Authors>
     <Product>ReactView</Product>
     <Copyright>Copyright © OutSystems 2023</Copyright>
@@ -17,7 +17,7 @@
 
   <PropertyGroup>
     <AvaloniaVersion>11.0.10</AvaloniaVersion>
-    <WebViewVersion>3.120.5</WebViewVersion>
+    <WebViewVersion>3.120.7</WebViewVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)' == '' or '$(Platform)' == 'x64'">


### PR DESCRIPTION
Following https://github.com/chromiumembedded/cef/issues/3250 and https://bitbucket.org/chromiumembedded/cef/commits/85c53029bf07, this PR aims at increasing the cef stack size to 8 MiBs. To do so, we use the visual studio tool "editbin".

Similarly to https://github.com/cefsharp/CefSharp/blob/d0486b317967fe4a3eb00e783c26d93d2a00e594/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.netcore.csproj#L67, we want to run editbin after building to increase the stack size to 8 MiBs.

Differenly from the link above, I tried drying the code a bit and make it more readable.

Please refer to https://github.com/OutSystems/CefGlue/pull/172 and https://github.com/OutSystems/WebView/pull/361 for more details.