### PR TITLE
RDEV-9547 - Rebinding inner views on remount

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <!-- Please see https://github.com/OutSystems/reactview?tab=readme-ov-file#versioning for versioning rules -->
-    <Version>5.120.3</Version>
+    <Version>5.120.4</Version>
     <Authors>OutSystems</Authors>
     <Product>ReactView</Product>
     <Copyright>Copyright © OutSystems 2023</Copyright>

--- a/ReactViewControl/ReactViewRender.cs
+++ b/ReactViewControl/ReactViewRender.cs
@@ -26,7 +26,7 @@ namespace ReactViewControl {
 
         private Dictionary<string, FrameInfo> Frames { get; } = new Dictionary<string, FrameInfo>();
         private Dictionary<string, WeakReference<FrameInfo>> RecoverableFrames { get; } = new Dictionary<string, WeakReference<FrameInfo>>();
-        private Dictionary<string, IViewModule> ChildViewModules { get; } = new Dictionary<string, IViewModule>();
+        private Dictionary<string, WeakReference<IViewModule>> ChildViewModules { get; } = new Dictionary<string, WeakReference<IViewModule>>();
 
         private ExtendedWebView WebView { get; }
         private Assembly UserCallingAssembly { get; }
@@ -410,7 +410,7 @@ namespace ReactViewControl {
             frame.Component = component;
             component.Bind(frame, this);
             if (!frame.IsMain) {
-                ChildViewModules[frame.Name] = component;
+                ChildViewModules[frame.Name] = new WeakReference<IViewModule>(component);
             }
         }
 
@@ -610,11 +610,14 @@ namespace ReactViewControl {
             Frames[frameName] = newFrame;
             AddPlugins(PluginsFactory(), newFrame);
 
-            // The old FrameInfo was destroyed. The IViewModule itself is
-            // kept alive by ChildViewModules, so rebind it to this new frame.
-            if (!newFrame.IsMain && ChildViewModules.TryGetValue(frameName, out var existingComponent)) {
-                BindComponentToFrame(existingComponent, newFrame);
-                newFrame.IsComponentReadyToLoad = true;
+            // Rebind the existing IViewModule (kept by the consumer) to the new frame on remount
+            if (!newFrame.IsMain && ChildViewModules.TryGetValue(frameName, out var weakComponent)) {
+                if (weakComponent.TryGetTarget(out var existingComponent)) {
+                    BindComponentToFrame(existingComponent, newFrame);
+                    newFrame.IsComponentReadyToLoad = true;
+                } else {
+                    ChildViewModules.Remove(frameName);
+                }
             }
 
             return newFrame;

--- a/ReactViewControl/ReactViewRender.cs
+++ b/ReactViewControl/ReactViewRender.cs
@@ -26,6 +26,7 @@ namespace ReactViewControl {
 
         private Dictionary<string, FrameInfo> Frames { get; } = new Dictionary<string, FrameInfo>();
         private Dictionary<string, WeakReference<FrameInfo>> RecoverableFrames { get; } = new Dictionary<string, WeakReference<FrameInfo>>();
+        private Dictionary<string, IViewModule> ChildViewModules { get; } = new Dictionary<string, IViewModule>();
 
         private ExtendedWebView WebView { get; }
         private Assembly UserCallingAssembly { get; }
@@ -205,6 +206,7 @@ namespace ReactViewControl {
 
                 Frames.Clear();
                 Frames.Add(mainFrame.Name, mainFrame);
+                ChildViewModules.Clear();
                 var previousComponentReady = mainFrame.IsComponentReadyToLoad;
                 mainFrame.Reset();
                 mainFrame.IsComponentReadyToLoad = previousComponentReady;
@@ -407,6 +409,9 @@ namespace ReactViewControl {
         private void BindComponentToFrame(IViewModule component, FrameInfo frame) {
             frame.Component = component;
             component.Bind(frame, this);
+            if (!frame.IsMain) {
+                ChildViewModules[frame.Name] = component;
+            }
         }
 
         /// <summary>
@@ -604,6 +609,13 @@ namespace ReactViewControl {
             var newFrame = new FrameInfo(frameName);
             Frames[frameName] = newFrame;
             AddPlugins(PluginsFactory(), newFrame);
+
+            // The old FrameInfo was destroyed. The IViewModule itself is
+            // kept alive by ChildViewModules, so rebind it to this new frame.
+            if (!newFrame.IsMain && ChildViewModules.TryGetValue(frameName, out var existingComponent)) {
+                BindComponentToFrame(existingComponent, newFrame);
+                newFrame.IsComponentReadyToLoad = true;
+            }
 
             return newFrame;
         }


### PR DESCRIPTION
The IViewModule class was being erased when the FrameInfo was destroyed. With this in the remount a new module was created and this module iddnt contain the presenter subscritions. And IsComponentReadyToLoad started to false blocking TryLoadComponent

We don't need to stash nativeObjectNames because they are reregisterd when each new FrameInfo
We can't do statsh of React component and since we only keep the IViewModule (c# class) so the Portal/ExecutiuonEngine all die 
PropertiesProxy is preserved since it lives inside IViewModule
Portal is destroyd in  NotifyViewDestroyed
The bridge that we keep is the IViewMOdule and its subscritions to events stay alive and reconected to the new frame
No changes in the iframes paths