### PR TITLE
RDEV-10097 - Load each script once per document, and release load listeners

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <!-- Please see https://github.com/OutSystems/reactview?tab=readme-ov-file#versioning for versioning rules -->
-    <Version>5.120.4</Version>
+    <Version>5.120.5</Version>
     <Authors>OutSystems</Authors>
     <Product>ReactView</Product>
     <Copyright>Copyright © OutSystems 2023</Copyright>

--- a/ReactViewControl/ReactView.cs
+++ b/ReactViewControl/ReactView.cs
@@ -19,7 +19,7 @@ namespace ReactViewControl {
 
         private static ReactViewRender CreateReactViewInstance(ReactViewFactory factory) {
             ReactViewRender InnerCreateView() {
-                var view = new ReactViewRender(factory.DefaultStyleSheet, () => factory.InitializePlugins(), factory.EnableViewPreload, factory.EnableDebugMode, factory.EnsureInnerViewsAreDisposed);
+                var view = new ReactViewRender(factory.DefaultStyleSheet, () => factory.InitializePlugins(), factory.EnableViewPreload, factory.EnableDebugMode, factory.EnsureInnerViewsAreDisposed, factory.LoadScriptsOncePerDocument);
                 if (factory.ShowDeveloperTools) {
                     view.ShowDeveloperTools();
                 }

--- a/ReactViewControl/ReactViewFactory.cs
+++ b/ReactViewControl/ReactViewFactory.cs
@@ -32,5 +32,12 @@ namespace ReactViewControl {
         public virtual bool EnableViewPreload => true;
 
         public virtual bool EnsureInnerViewsAreDisposed => true;
+
+        /// <summary>
+        /// Each script is loaded once per document, instead of once per view. Inner views are shadow roots,
+        /// and shadow dom does not encapsulate scripts, so a script appended for one view has already
+        /// executed for every other one. Set to false to restore the previous per view behaviour.
+        /// </summary>
+        public virtual bool LoadScriptsOncePerDocument => true;
     }
 }

--- a/ReactViewControl/ReactViewRender.LoaderModule.cs
+++ b/ReactViewControl/ReactViewRender.LoaderModule.cs
@@ -22,7 +22,7 @@ namespace ReactViewControl {
             /// <summary>
             /// Loads the specified react component into the specified frame
             /// </summary>
-            public void LoadComponent(IViewModule component, string frameName, bool hasStyleSheet, bool hasPlugins, bool ensureDisposeInnerViews) {
+            public void LoadComponent(IViewModule component, string frameName, bool hasStyleSheet, bool hasPlugins, bool ensureDisposeInnerViews, bool loadScriptsOncePerDocument) {
                 var mainSource = ViewRender.ToFullUrl(NormalizeUrl(component.MainJsSource));
                 var dependencySources = component.DependencyJsSources.Select(s => ViewRender.ToFullUrl(NormalizeUrl(s))).ToArray();
                 var cssSources = component.CssSources.Select(s => ViewRender.ToFullUrl(NormalizeUrl(s))).ToArray();
@@ -43,6 +43,8 @@ namespace ReactViewControl {
                 // componentNativeObject: Dictionary<any>,
                 // frameName: string
                 // componentHash: string
+                // ensureDisposeInnerViews: boolean
+                // loadScriptsOncePerDocument: boolean
 
                 var loadArgs = new[] {
                     JavascriptSerializer.Serialize(component.Name),
@@ -57,6 +59,7 @@ namespace ReactViewControl {
                     JavascriptSerializer.Serialize(frameName),
                     JavascriptSerializer.Serialize(componentHash),
                     JavascriptSerializer.Serialize(ensureDisposeInnerViews),
+                    JavascriptSerializer.Serialize(loadScriptsOncePerDocument),
                 };
 
                 ExecuteLoaderFunction("loadComponent", loadArgs);

--- a/ReactViewControl/ReactViewRender.cs
+++ b/ReactViewControl/ReactViewRender.cs
@@ -37,9 +37,11 @@ namespace ReactViewControl {
         private ResourceUrl defaultStyleSheet;
         private bool isInputDisabled; // used primarly to control the intention to disable input (before the browser is ready)
         private readonly bool ensureDisposeInnerViews;
+        private readonly bool loadScriptsOncePerDocument;
 
-        public ReactViewRender(ResourceUrl defaultStyleSheet, Func<IViewModule[]> initializePlugins, bool preloadWebView, bool enableDebugMode, bool ensureInnerViewsAreDisposed) {
+        public ReactViewRender(ResourceUrl defaultStyleSheet, Func<IViewModule[]> initializePlugins, bool preloadWebView, bool enableDebugMode, bool ensureInnerViewsAreDisposed, bool loadScriptsOncePerDocument = true) {
             this.ensureDisposeInnerViews = ensureInnerViewsAreDisposed;
+            this.loadScriptsOncePerDocument = loadScriptsOncePerDocument;
             UserCallingAssembly = GetUserCallingMethod().ReflectedType.Assembly;
 
             // must useSharedDomain for the local storage to be shared
@@ -274,7 +276,7 @@ namespace ReactViewControl {
 
             RegisterNativeObject(frame.Component, frame);
 
-            Loader.LoadComponent(frame.Component, frame.Name, DefaultStyleSheet != null, frame.Plugins.Length > 0, ensureDisposeInnerViews);
+            Loader.LoadComponent(frame.Component, frame.Name, DefaultStyleSheet != null, frame.Plugins.Length > 0, ensureDisposeInnerViews, loadScriptsOncePerDocument);
             if (isInputDisabled && frame.IsMain) {
                 Loader.DisableMouseInteractions();
             }

--- a/ReactViewResources/Loader/Bootstrap.ts
+++ b/ReactViewResources/Loader/Bootstrap.ts
@@ -1,7 +1,7 @@
 ﻿import { waitForDOMReady } from "./Internal/Common";
 import { libsPath, mainFrameName, webViewRootId } from "./Internal/Environment";
 import { loadScript } from "./Internal/ResourcesLoader";
-import { newView } from "./Internal/ViewMetadata";
+import { newView, ViewMetadata } from "./Internal/ViewMetadata";
 
 declare function define(name: string, dependencies: string[], definition: Function);
 
@@ -17,20 +17,20 @@ async function bootstrap() {
     mainView.head = document.head;
     mainView.root = rootElement;
 
-    await loadFramework();
+    await loadFramework(mainView);
 
     const loader = await import("./Loader");
     loader.initialize(mainView);
 }
 
-async function loadFramework(): Promise<void> {
+async function loadFramework(view: ViewMetadata): Promise<void> {
     const reactLib: string = "React";
     const reactDOMLib: string = "ReactDOM";
     const externalLibsPath = libsPath + "node_modules/";
 
-    await loadScript(externalLibsPath + "prop-types/prop-types.min.js"); /* Prop-Types */
-    await loadScript(externalLibsPath + "react/umd/react.production.min.js"); /* React */
-    await loadScript(externalLibsPath + "react-dom/umd/react-dom.production.min.js"); /* ReactDOM */
+    await loadScript(externalLibsPath + "prop-types/prop-types.min.js", view); /* Prop-Types */
+    await loadScript(externalLibsPath + "react/umd/react.production.min.js", view); /* React */
+    await loadScript(externalLibsPath + "react-dom/umd/react-dom.production.min.js", view); /* ReactDOM */
 
     define("react", [], () => window[reactLib]);
     define("react-dom", [], () => window[reactDOMLib]);

--- a/ReactViewResources/Loader/Bootstrap.ts
+++ b/ReactViewResources/Loader/Bootstrap.ts
@@ -1,7 +1,7 @@
 ﻿import { waitForDOMReady } from "./Internal/Common";
 import { libsPath, mainFrameName, webViewRootId } from "./Internal/Environment";
 import { loadScript } from "./Internal/ResourcesLoader";
-import { newView, ViewMetadata } from "./Internal/ViewMetadata";
+import { newView } from "./Internal/ViewMetadata";
 
 declare function define(name: string, dependencies: string[], definition: Function);
 
@@ -17,20 +17,20 @@ async function bootstrap() {
     mainView.head = document.head;
     mainView.root = rootElement;
 
-    await loadFramework(mainView);
+    await loadFramework();
 
     const loader = await import("./Loader");
     loader.initialize(mainView);
 }
 
-async function loadFramework(view: ViewMetadata): Promise<void> {
+async function loadFramework(): Promise<void> {
     const reactLib: string = "React";
     const reactDOMLib: string = "ReactDOM";
     const externalLibsPath = libsPath + "node_modules/";
 
-    await loadScript(externalLibsPath + "prop-types/prop-types.min.js", view); /* Prop-Types */
-    await loadScript(externalLibsPath + "react/umd/react.production.min.js", view); /* React */
-    await loadScript(externalLibsPath + "react-dom/umd/react-dom.production.min.js", view); /* ReactDOM */
+    await loadScript(externalLibsPath + "prop-types/prop-types.min.js"); /* Prop-Types */
+    await loadScript(externalLibsPath + "react/umd/react.production.min.js"); /* React */
+    await loadScript(externalLibsPath + "react-dom/umd/react-dom.production.min.js"); /* ReactDOM */
 
     define("react", [], () => window[reactLib]);
     define("react-dom", [], () => window[reactDOMLib]);

--- a/ReactViewResources/Loader/Internal/Flags.ts
+++ b/ReactViewResources/Loader/Internal/Flags.ts
@@ -1,0 +1,11 @@
+// flags set by the host on the main view load, kept here rather than in ViewMetadataContext because that
+// module depends on react, and bootstrap reads flags before react has been defined
+const LoadScriptsOncePerDocumentFlagKey = "LOAD_SCRIPTS_ONCE_PER_DOCUMENT";
+
+export function getLoadScriptsOncePerDocumentFlag(): boolean {
+    return !!window[LoadScriptsOncePerDocumentFlagKey];
+}
+
+export function setLoadScriptsOncePerDocumentFlag(loadScriptsOncePerDocument: boolean): void {
+    window[LoadScriptsOncePerDocumentFlagKey] = loadScriptsOncePerDocument;
+}

--- a/ReactViewResources/Loader/Internal/ResourcesLoader.ts
+++ b/ReactViewResources/Loader/Internal/ResourcesLoader.ts
@@ -1,23 +1,16 @@
 ﻿import { defaultLoadResourcesTimeout, isDebugModeEnabled } from "./Environment";
 import { showWarningMessage } from "./MessagesProvider";
 import { Task } from "./Task";
-import { ViewMetadata } from "./ViewMetadata";
 
 // inner views are shadow roots rather than frames, and shadow dom encapsulates styles but not scripts, so
 // a script that has been appended for one view has executed for every other one as well. tracking these
 // per view re-executes the same bundle once per view.
 const scriptLoadTasks = new Map<string, Task<void>>();
 
-export function loadScript(scriptSrc: string, view: ViewMetadata): Promise<void> {
+export function loadScript(scriptSrc: string): Promise<void> {
     const pendingLoad = scriptLoadTasks.get(scriptSrc);
     if (pendingLoad) {
         return pendingLoad.promise;
-    }
-
-    // checked before the task is registered, so that a view without a head does not leave behind a load
-    // that nothing can ever resolve
-    if (!view.head) {
-        throw new Error(`View ${view.name} head is not set`);
     }
 
     const loadTask = new Task<void>();
@@ -31,7 +24,9 @@ export function loadScript(scriptSrc: string, view: ViewMetadata): Promise<void>
     waitForLoad(script, scriptSrc, defaultLoadResourcesTimeout, () => scriptLoadTasks.delete(scriptSrc))
         .then(() => loadTask.setResult());
 
-    view.head.appendChild(script);
+    // not the requesting view's head: it may already be detached, and a script in a detached tree never
+    // runs, so the task above would neither resolve nor fail
+    document.head.appendChild(script);
 
     return loadTask.promise;
 }

--- a/ReactViewResources/Loader/Internal/ResourcesLoader.ts
+++ b/ReactViewResources/Loader/Internal/ResourcesLoader.ts
@@ -63,9 +63,25 @@ function waitForLoad<T extends HTMLElement>(element: T, url: string, timeout: nu
             },
             timeout);
 
-        element.addEventListener("load", () => {
+        // both listeners capture the element, so whichever outcome happens first has to remove them. the
+        // timeout only warns and never cleans up, so a resource that loads after it still resolves.
+        function cleanup(): void {
             clearTimeout(timeoutHandle);
+            element.removeEventListener("load", onLoad);
+            element.removeEventListener("error", onError);
+        }
+
+        function onLoad(): void {
+            cleanup();
             resolve(element);
-        });
+        }
+
+        // a failed resource is not reported back, since no caller handles one today
+        function onError(): void {
+            cleanup();
+        }
+
+        element.addEventListener("load", onLoad);
+        element.addEventListener("error", onError);
     });
 }

--- a/ReactViewResources/Loader/Internal/ResourcesLoader.ts
+++ b/ReactViewResources/Loader/Internal/ResourcesLoader.ts
@@ -1,13 +1,22 @@
-﻿import { defaultLoadResourcesTimeout, isDebugModeEnabled } from "./Environment";
+﻿import { defaultLoadResourcesTimeout, isDebugModeEnabled, mainFrameName } from "./Environment";
 import { showWarningMessage } from "./MessagesProvider";
 import { Task } from "./Task";
+import { ViewMetadata } from "./ViewMetadata";
+import { getLoadScriptsOncePerDocumentFlag } from "./Flags";
+import { getView } from "./ViewsCollection";
 
 // inner views are shadow roots rather than frames, and shadow dom encapsulates styles but not scripts, so
 // a script that has been appended for one view has executed for every other one as well. tracking these
 // per view re-executes the same bundle once per view.
 const scriptLoadTasks = new Map<string, Task<void>>();
 
-export function loadScript(scriptSrc: string): Promise<void> {
+export function loadScript(scriptSrc: string, view: ViewMetadata): Promise<void> {
+    // bootstrap runs before the flag is set, but it only loads scripts for the main view, whose head is the
+    // document head and whose per view map is the one the legacy path reads, so both paths behave alike there
+    if (!getLoadScriptsOncePerDocumentFlag()) {
+        return loadScriptPerView(scriptSrc, view);
+    }
+
     const pendingLoad = scriptLoadTasks.get(scriptSrc);
     if (pendingLoad) {
         return pendingLoad.promise;
@@ -29,6 +38,43 @@ export function loadScript(scriptSrc: string): Promise<void> {
     document.head.appendChild(script);
 
     return loadTask.promise;
+}
+
+/**
+ * Pre 5.120.5 behaviour, kept behind LoadScriptsOncePerDocument so that it can be restored. Reproduced as it
+ * was, quirks included: the condition below reads as (ownTask || !isMain) ? mainFrameTask : null, so the
+ * view's own entry is only ever a truthiness test and inner views never reuse what they registered.
+ */
+function loadScriptPerView(scriptSrc: string, view: ViewMetadata): Promise<void> {
+    return new Promise(async (resolve) => {
+        const frameScripts = view.scriptsLoadTasks;
+
+        // check if script was already added, fallback to main frame
+        const scriptLoadTask = frameScripts.get(scriptSrc) || !view.isMain ? getView(mainFrameName).scriptsLoadTasks.get(scriptSrc) : null;
+        if (scriptLoadTask) {
+            // wait for script to be loaded
+            await scriptLoadTask.promise;
+            resolve();
+            return;
+        }
+
+        const loadTask = new Task<void>();
+        frameScripts.set(scriptSrc, loadTask);
+
+        const script = document.createElement("script");
+        script.src = scriptSrc;
+
+        waitForLoad(script, scriptSrc, defaultLoadResourcesTimeout)
+            .then(() => {
+                loadTask.setResult();
+                resolve();
+            });
+
+        if (!view.head) {
+            throw new Error(`View ${view.name} head is not set`);
+        }
+        view.head.appendChild(script);
+    });
 }
 
 export function loadStyleSheet(stylesheet: string, containerElement: Element, markAsSticky: boolean): Promise<HTMLLinkElement> {

--- a/ReactViewResources/Loader/Internal/ResourcesLoader.ts
+++ b/ReactViewResources/Loader/Internal/ResourcesLoader.ts
@@ -1,39 +1,39 @@
-﻿import { defaultLoadResourcesTimeout, isDebugModeEnabled, mainFrameName } from "./Environment";
+﻿import { defaultLoadResourcesTimeout, isDebugModeEnabled } from "./Environment";
 import { showWarningMessage } from "./MessagesProvider";
 import { Task } from "./Task";
 import { ViewMetadata } from "./ViewMetadata";
-import { getView } from "./ViewsCollection";
+
+// inner views are shadow roots rather than frames, and shadow dom encapsulates styles but not scripts, so
+// a script that has been appended for one view has executed for every other one as well. tracking these
+// per view re-executes the same bundle once per view.
+const scriptLoadTasks = new Map<string, Task<void>>();
 
 export function loadScript(scriptSrc: string, view: ViewMetadata): Promise<void> {
-    return new Promise(async (resolve) => {
-        const frameScripts = view.scriptsLoadTasks;
+    const pendingLoad = scriptLoadTasks.get(scriptSrc);
+    if (pendingLoad) {
+        return pendingLoad.promise;
+    }
 
-        // check if script was already added, fallback to main frame
-        const scriptLoadTask = frameScripts.get(scriptSrc) || !view.isMain ? getView(mainFrameName).scriptsLoadTasks.get(scriptSrc) : null;
-        if (scriptLoadTask) {
-            // wait for script to be loaded
-            await scriptLoadTask.promise;
-            resolve();
-            return;
-        }
+    // checked before the task is registered, so that a view without a head does not leave behind a load
+    // that nothing can ever resolve
+    if (!view.head) {
+        throw new Error(`View ${view.name} head is not set`);
+    }
 
-        const loadTask = new Task<void>();
-        frameScripts.set(scriptSrc, loadTask);
+    const loadTask = new Task<void>();
+    scriptLoadTasks.set(scriptSrc, loadTask);
 
-        const script = document.createElement("script");
-        script.src = scriptSrc;
+    const script = document.createElement("script");
+    script.src = scriptSrc;
 
-        waitForLoad(script, scriptSrc, defaultLoadResourcesTimeout)
-            .then(() => {
-                loadTask.setResult();
-                resolve();
-            });
+    // a script that fails is dropped, so that a later view can attempt it again. one that times out is
+    // kept, since it may still arrive
+    waitForLoad(script, scriptSrc, defaultLoadResourcesTimeout, () => scriptLoadTasks.delete(scriptSrc))
+        .then(() => loadTask.setResult());
 
-        if (!view.head) {
-            throw new Error(`View ${view.name} head is not set`);
-        }
-        view.head.appendChild(script);
-    });
+    view.head.appendChild(script);
+
+    return loadTask.promise;
 }
 
 export function loadStyleSheet(stylesheet: string, containerElement: Element, markAsSticky: boolean): Promise<HTMLLinkElement> {
@@ -53,7 +53,7 @@ export function loadStyleSheet(stylesheet: string, containerElement: Element, ma
     });
 }
 
-function waitForLoad<T extends HTMLElement>(element: T, url: string, timeout: number): Promise<T> {
+function waitForLoad<T extends HTMLElement>(element: T, url: string, timeout: number, onFailed?: () => void): Promise<T> {
     return new Promise((resolve) => {
         const timeoutHandle = setTimeout(
             () => {
@@ -79,6 +79,9 @@ function waitForLoad<T extends HTMLElement>(element: T, url: string, timeout: nu
         // a failed resource is not reported back, since no caller handles one today
         function onError(): void {
             cleanup();
+            if (onFailed) {
+                onFailed();
+            }
         }
 
         element.addEventListener("load", onLoad);

--- a/ReactViewResources/Loader/Internal/ViewMetadata.ts
+++ b/ReactViewResources/Loader/Internal/ViewMetadata.ts
@@ -9,7 +9,6 @@ export type ViewMetadata = {
     placeholder: Element; // element were the view is mounted (where the shadow root is mounted in case of child views)
     root?: Element; // view root element
     head?: Element; // view head element
-    scriptsLoadTasks: Map<string, Task<void>>; // maps scripts urls to load tasks
     pluginsLoadTask: Task<void>; // plugins load task
     viewLoadTask: Task<void>; // resolved when view is loaded
     modules: Map<string, any>; // maps module name to module instance
@@ -33,7 +32,6 @@ export function newView(id: number, name: string, isMain: boolean, placeholder: 
         nativeObjectNames: [],
         pluginsLoadTask: new Task(),
         viewLoadTask: new Task(),
-        scriptsLoadTasks: new Map<string, Task<void>>(),
         childViews: new ObservableListCollection<ViewMetadata>(),
         context: null,
         parentView: null!

--- a/ReactViewResources/Loader/Internal/ViewMetadata.ts
+++ b/ReactViewResources/Loader/Internal/ViewMetadata.ts
@@ -9,6 +9,7 @@ export type ViewMetadata = {
     placeholder: Element; // element were the view is mounted (where the shadow root is mounted in case of child views)
     root?: Element; // view root element
     head?: Element; // view head element
+    scriptsLoadTasks: Map<string, Task<void>>; // maps script source to load task, only used when scripts are tracked per view
     pluginsLoadTask: Task<void>; // plugins load task
     viewLoadTask: Task<void>; // resolved when view is loaded
     modules: Map<string, any>; // maps module name to module instance
@@ -29,6 +30,7 @@ export function newView(id: number, name: string, isMain: boolean, placeholder: 
         head: undefined,
         root: undefined,
         modules: new Map<string, any>(),
+        scriptsLoadTasks: new Map<string, Task<void>>(),
         nativeObjectNames: [],
         pluginsLoadTask: new Task(),
         viewLoadTask: new Task(),

--- a/ReactViewResources/Loader/Loader.ts
+++ b/ReactViewResources/Loader/Loader.ts
@@ -12,6 +12,7 @@ import { ViewMetadata } from "./Internal/ViewMetadata";
 import { createPropertiesProxy } from "./Internal/ViewPropertiesProxy";
 import { addView, getView, tryGetView } from "./Internal/ViewsCollection";
 import { setEnsureDisposeInnerViewsFlag } from "./Internal/ViewMetadataContext";
+import { setLoadScriptsOncePerDocumentFlag } from "./Internal/Flags";
 
 export { disableMouseInteractions, enableMouseInteractions } from "./Internal/InputManager";
 export { showErrorMessage } from "./Internal/MessagesProvider";
@@ -84,11 +85,11 @@ export function loadPlugins(plugins: any[][], frameName: string): void {
                     if (view.isMain) {
                         // only load plugins sources once (in the main frame)
                         // load plugin dependency js sources
-                        const dependencySourcesPromises = dependencySources.map(s => loadScript(s));
+                        const dependencySourcesPromises = dependencySources.map(s => loadScript(s, view));
                         await Promise.all(dependencySourcesPromises);
 
                         // plugin main js source
-                        await loadScript(mainJsSource);
+                        await loadScript(mainJsSource, view);
                     }
 
                     const module = getPluginModule(moduleName) || getViewModule(moduleName);
@@ -128,7 +129,8 @@ export function loadComponent(
     componentNativeObject: any,
     frameName: string,
     componentHash: string,
-    ensureDisposeInnerViews: boolean): void {
+    ensureDisposeInnerViews: boolean,
+    loadScriptsOncePerDocument: boolean): void {
 
     async function innerLoad() {
         let view: ViewMetadata;
@@ -140,6 +142,8 @@ export function loadComponent(
             
             if (frameName === mainFrameName) {
                 setEnsureDisposeInnerViewsFlag(ensureDisposeInnerViews);
+                // the main view always loads first, so the flag is set before any inner view loads a script
+                setLoadScriptsOncePerDocumentFlag(loadScriptsOncePerDocument);
             }
 
             view = tryGetView(frameName)!;
@@ -163,12 +167,12 @@ export function loadComponent(
             await Promise.all(promisesToWaitFor);
 
             // load component dependencies js sources and css sources
-            const dependencyLoadPromises = dependencySources.map(s => loadScript(s) as Promise<any>)
+            const dependencyLoadPromises = dependencySources.map(s => loadScript(s, view) as Promise<any>)
                 .concat(cssSources.map(s => loadStyleSheet(s, head, false)));
             await Promise.all(dependencyLoadPromises);
 
             // main component script should be the last to be loaded, otherwise errors might occur
-            await loadScript(componentSource);
+            await loadScript(componentSource, view);
 
             const renderFinishedTask = cacheEntry ? view.viewLoadTask : null;
             // create proxy for properties obj to delay its methods execution until native object is ready

--- a/ReactViewResources/Loader/Loader.ts
+++ b/ReactViewResources/Loader/Loader.ts
@@ -84,11 +84,11 @@ export function loadPlugins(plugins: any[][], frameName: string): void {
                     if (view.isMain) {
                         // only load plugins sources once (in the main frame)
                         // load plugin dependency js sources
-                        const dependencySourcesPromises = dependencySources.map(s => loadScript(s, view));
+                        const dependencySourcesPromises = dependencySources.map(s => loadScript(s));
                         await Promise.all(dependencySourcesPromises);
 
                         // plugin main js source
-                        await loadScript(mainJsSource, view);
+                        await loadScript(mainJsSource);
                     }
 
                     const module = getPluginModule(moduleName) || getViewModule(moduleName);
@@ -163,12 +163,12 @@ export function loadComponent(
             await Promise.all(promisesToWaitFor);
 
             // load component dependencies js sources and css sources
-            const dependencyLoadPromises = dependencySources.map(s => loadScript(s, view) as Promise<any>)
+            const dependencyLoadPromises = dependencySources.map(s => loadScript(s) as Promise<any>)
                 .concat(cssSources.map(s => loadStyleSheet(s, head, false)));
             await Promise.all(dependencyLoadPromises);
 
             // main component script should be the last to be loaded, otherwise errors might occur
-            await loadScript(componentSource, view);
+            await loadScript(componentSource);
 
             const renderFinishedTask = cacheEntry ? view.viewLoadTask : null;
             // create proxy for properties obj to delay its methods execution until native object is ready


### PR DESCRIPTION
Two fixes to `ResourcesLoader`, rescued from #208.

## 1. Scripts were loaded, and re-executed, once per view

Inner views are shadow roots rather than frames — `attachShadow` in `ViewPortal` and `ViewFrame`, with no `contentDocument` anywhere — and shadow DOM encapsulates styles but not scripts. A `<script src>` appended for one view has therefore executed for the whole document. `loadScript` nevertheless tracked loads in a per-view map, falling back to the main frame's map.

That fallback never worked:

```js
const scriptLoadTask = frameScripts.get(scriptSrc) || !view.isMain ? getView(mainFrameName).scriptsLoadTasks.get(scriptSrc) : null;
```

`||` binds tighter than `?:`, so this parses as `(frameScripts.get(scriptSrc) || !view.isMain) ? mainFrameTask : null`. The view's own entry is only ever a truthiness test and the value taken is always the main frame's task. For an inner view `!isMain` is `true`, so the condition is constant and the lookup only ever consults the main frame — the entry written for the view itself is unreachable. Inner views re-loaded, and re-executed, scripts that another inner view had already loaded. The cost is not the network request, which the HTTP cache absorbs, but re-running a UMD bundle into the same document.

Replaced with a single document-wide map, which is what the lifetime of a script actually matches, and dropped the now unused `scriptsLoadTasks` from `ViewMetadata`. A script that fails is removed so a later view can attempt it again; one that times out is kept, since it may still arrive.

## 2. Load listeners and timeouts outlived the resource

`waitForLoad` left its `load` listener attached to the element after the resource had loaded, and had no `error` handler at all, so a resource that failed to load kept both the listener and the pending timeout alive for the lifetime of the document. Both are now released as soon as the outcome is known.

## Behaviour changes to be aware of

- `loadScript` now throws synchronously when `view.head` is unset, and does so before registering the task. It previously threw *after* registering, leaving an entry nothing could resolve, and from inside an async promise executor — so the throw became an unhandled rejection and the caller hung. Every call site is async, so it now surfaces as a rejection.
- The timeout still only warns and tears nothing down, so a resource arriving after the warning resolves as before.
- `onError` does not reject. None of the `await` sites in `Bootstrap.ts` or `Loader.ts` handles an error, so a caller awaiting a failed resource still hangs, as it does today. Turning that into a real error is worth doing but needs those call sites audited first.

## Not taken from #208

The rest of that PR is either superseded by #211, which covers the `ViewFrame` / `ViewPortal` / `Loader.View` rework behind the `getEnsureDisposeInnerViewsFlag()` flag, or was debug scaffolding — `debugger` statements, `console.log`s and a commented-out render cache. Its version of this fix put the registry on `window` under two keys, but assigned `window[LoadedScriptsKey]` in both initialiser branches, so the task map was never actually stored; it also recorded a script as loaded before the load completed, so a failed script was permanently treated as present.

## Test plan

- [ ] `tsc --noEmit -p ReactViewResources/Loader/tsconfig.json` passes (verified locally)
- [ ] Views load scripts and stylesheets normally
- [ ] A second inner view requiring the same dependency does not add a second `<script>` to the document
- [ ] A resource that 404s leaves no listener on the element and no pending timeout, and can be requested again
- [ ] A slow resource that arrives after the timeout warning still resolves

> [!IMPORTANT]
> `RDEV-0000` needs replacing with a real ticket before merge — #208 had no ticket to inherit.