### PR TITLE
RDEV-10097 - Name the unbound native object when a view property is called

### DIFF
--- a/ReactViewResources/Loader/Internal/NativeAPI.ts
+++ b/ReactViewResources/Loader/Internal/NativeAPI.ts
@@ -21,7 +21,17 @@ function withAPI(action: (api: INativeObject) => void): void {
 
 export async function bindNativeObject<T>(nativeObjectName: string): Promise<T> {
     await cefglue.checkObjectBound(nativeObjectName);
-    return window[nativeObjectName] as T;
+
+    const nativeObject = window[nativeObjectName] as T;
+    if (!nativeObject) {
+        // An object that never bound, or that was unbound along with the view holding it, is handed over
+        // missing otherwise, and each caller then fails on its own: the properties proxy on the method it was
+        // asked for, the plugins on the instance they build with it. By then the name is gone, and what the
+        // console reports is a property read on undefined somewhere inside the bundle.
+        throw new Error(`The native object "${nativeObjectName}" is not bound. The view holding it was most likely already destroyed.`);
+    }
+
+    return nativeObject;
 }
 
 export function notifyViewInitialized(viewName: string): void {

--- a/ReactViewResources/Loader/Internal/NativeAPI.ts
+++ b/ReactViewResources/Loader/Internal/NativeAPI.ts
@@ -21,17 +21,7 @@ function withAPI(action: (api: INativeObject) => void): void {
 
 export async function bindNativeObject<T>(nativeObjectName: string): Promise<T> {
     await cefglue.checkObjectBound(nativeObjectName);
-
-    const nativeObject = window[nativeObjectName] as T;
-    if (!nativeObject) {
-        // An object that never bound, or that was unbound along with the view holding it, is handed over
-        // missing otherwise, and each caller then fails on its own: the properties proxy on the method it was
-        // asked for, the plugins on the instance they build with it. By then the name is gone, and what the
-        // console reports is a property read on undefined somewhere inside the bundle.
-        throw new Error(`The native object "${nativeObjectName}" is not bound. The view holding it was most likely already destroyed.`);
-    }
-
-    return nativeObject;
+    return window[nativeObjectName] as T;
 }
 
 export function notifyViewInitialized(viewName: string): void {

--- a/ReactViewResources/Loader/Internal/ViewPropertiesProxy.ts
+++ b/ReactViewResources/Loader/Internal/ViewPropertiesProxy.ts
@@ -10,6 +10,12 @@ export function createPropertiesProxy(rootElement: Element, objProperties: {}, n
         } else {
             proxy[key] = async function () {
                 const nativeObject = window[nativeObjName] || await bindNativeObject(nativeObjName);
+                if (!nativeObject) {
+                    // Reading the method off the missing object is what reports this otherwise, and by then
+                    // both names are gone: what reaches the console is a property read on undefined, raised
+                    // somewhere inside the bundle.
+                    throw new Error(`Cannot call "${key}" on the native object "${nativeObjName}": it is not bound, and the view holding it was most likely already destroyed.`);
+                }
 
                 const result = nativeObject[key].apply(window, arguments);
 


### PR DESCRIPTION
## Summary

A view property backed by the native side is called through `createPropertiesProxy`, which resolves the object at call time. Once the view is destroyed the object is no longer bound, so `window[name]` is undefined, `bindNativeObject` hands that same undefined back, and the call dies reading the method off it:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'generateFinished')
    at proxy.<computed> [as generateFinished] (Loader.js:686:48)
```

That message names neither the object nor the view, and the frame it points at is inside the bundle, so the cause has to be reconstructed by hand. This raises the failure where the call is made, naming the method and the native object it belongs to.

Nothing that worked before fails now: the call already threw at exactly this point, so only the message changes. The check is deliberately here rather than in `bindNativeObject`, whose other two callers do not fail the same way — in particular, the plugin loading path skips `view.pluginsLoadTask.setResult()` when it catches, so a throw there leaves the view's load, and any child frame waiting on it, unresolved.

This is a diagnostics change, not a behavior fix. The crash above is fixed on the consumer side, where the UI Editor view no longer reports a finished generation after it has been torn down. This makes the next occurrence of the same class name itself.

## Test plan

- [x] `tsc --noEmit` over `ReactViewResources/Loader` is clean (26 files).
- [ ] No automated test added: the repository has no JS test harness (`ReactViewResources/package.json` still has the stub `test` script that exits 1).
- [ ] Smoke check in a host: close a view while a native round-trip is in flight and confirm the console names the method and the object instead of reporting undefined.